### PR TITLE
feat: Android market fragmentation handling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,18 +39,6 @@
             android:name=".LoginActivity"
             android:exported="false" />
         <activity
-            android:name=".ResetPasswordActivity"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data
-                    android:scheme="ucms"
-                    android:host="reset-password" />
-            </intent-filter>
-        </activity>
-        <activity
             android:name=".ForgotPasswordActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,8 +3,24 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.READ_MEDIA_IMAGES"
+        android:minSdkVersion="33" />
+    <uses-permission
+        android:name="android.permission.READ_MEDIA_VIDEO"
+        android:minSdkVersion="33" />
+    <uses-permission
+        android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED"
+        android:minSdkVersion="33" />
+    <uses-permission
+        android:name="android.permission.POST_NOTIFICATIONS"
+        android:minSdkVersion="33" />
 
     <application
+        android:name=".UcmsApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -23,6 +39,18 @@
             android:name=".LoginActivity"
             android:exported="false" />
         <activity
+            android:name=".ResetPasswordActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="ucms"
+                    android:host="reset-password" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".ForgotPasswordActivity"
             android:exported="false" />
         <activity
@@ -34,6 +62,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,18 +6,10 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
-    <uses-permission
-        android:name="android.permission.READ_MEDIA_IMAGES"
-        android:minSdkVersion="33" />
-    <uses-permission
-        android:name="android.permission.READ_MEDIA_VIDEO"
-        android:minSdkVersion="33" />
-    <uses-permission
-        android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED"
-        android:minSdkVersion="33" />
-    <uses-permission
-        android:name="android.permission.POST_NOTIFICATIONS"
-        android:minSdkVersion="33" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".UcmsApplication"

--- a/app/src/main/java/com/example/ucms_android/UcmsApplication.java
+++ b/app/src/main/java/com/example/ucms_android/UcmsApplication.java
@@ -1,0 +1,13 @@
+package com.example.ucms_android;
+
+import android.app.Application;
+
+import com.example.ucms_android.util.NotificationHelper;
+
+public class UcmsApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        NotificationHelper.createChannel(this);
+    }
+}

--- a/app/src/main/java/com/example/ucms_android/util/FilePickerHelper.java
+++ b/app/src/main/java/com/example/ucms_android/util/FilePickerHelper.java
@@ -38,6 +38,7 @@ public final class FilePickerHelper {
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
         intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false);
 
         if (mimeTypes.length == 1) {
@@ -170,6 +171,8 @@ public final class FilePickerHelper {
                     return cursor.getString(index);
                 }
             }
+        } catch (SecurityException | IllegalArgumentException e) {
+            android.util.Log.w("FilePickerHelper", "queryDisplayName failed: " + e.getMessage());
         }
 
         return null;
@@ -190,6 +193,8 @@ public final class FilePickerHelper {
                     return cursor.getString(index);
                 }
             }
+        } catch (SecurityException | IllegalArgumentException e) {
+            android.util.Log.w("FilePickerHelper", "queryMediaStoreDisplayName failed: " + e.getMessage());
         }
 
         return null;

--- a/app/src/main/java/com/example/ucms_android/util/FilePickerHelper.java
+++ b/app/src/main/java/com/example/ucms_android/util/FilePickerHelper.java
@@ -1,0 +1,227 @@
+package com.example.ucms_android.util;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.MediaStore;
+import android.provider.OpenableColumns;
+import android.webkit.MimeTypeMap;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
+
+public final class FilePickerHelper {
+    private static final String CACHE_ATTACHMENTS_DIR = "ticket_attachments";
+
+    private FilePickerHelper() {
+    }
+
+    public static void launchFilePicker(@NonNull ActivityResultLauncher<Intent> launcher) {
+        launchFilePicker(launcher, new String[]{"*/*"});
+    }
+
+    public static void launchFilePicker(
+            @NonNull ActivityResultLauncher<Intent> launcher,
+            @NonNull String[] mimeTypes
+    ) {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false);
+
+        if (mimeTypes.length == 1) {
+            intent.setType(mimeTypes[0]);
+        } else {
+            intent.setType("*/*");
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
+        }
+
+        launcher.launch(intent);
+    }
+
+    @NonNull
+    public static File getFileFromUri(@NonNull Context context, @NonNull Uri uri) throws IOException {
+        String fileName = getFileName(context, uri);
+        if (fileName == null || fileName.trim().isEmpty()) {
+            fileName = "attachment_" + System.currentTimeMillis();
+        }
+
+        String mimeType = getMimeType(context, uri);
+        String extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+        if (!fileName.contains(".") && extension != null && !extension.isEmpty()) {
+            fileName = fileName + "." + extension.toLowerCase(Locale.US);
+        }
+
+        fileName = sanitizeFileName(fileName);
+
+        File attachmentCacheDir = new File(context.getCacheDir(), CACHE_ATTACHMENTS_DIR);
+        if (!attachmentCacheDir.exists() && !attachmentCacheDir.mkdirs()) {
+            throw new IOException("Unable to create cache directory for attachments");
+        }
+
+        File outFile = createUniqueFile(attachmentCacheDir, fileName);
+        ContentResolver resolver = context.getContentResolver();
+
+        try (InputStream inputStream = resolver.openInputStream(uri);
+             FileOutputStream outputStream = new FileOutputStream(outFile)) {
+            if (inputStream == null) {
+                throw new IOException("Unable to open input stream for URI: " + uri);
+            }
+
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, bytesRead);
+            }
+            outputStream.flush();
+        }
+
+        return outFile;
+    }
+
+    @Nullable
+    public static String getMimeType(@NonNull Context context, @NonNull Uri uri) {
+        String mimeType = context.getContentResolver().getType(uri);
+        if (mimeType != null && !mimeType.isEmpty()) {
+            return mimeType;
+        }
+
+        String fileName = getFileName(context, uri);
+        if (fileName != null) {
+            String extension = MimeTypeMap.getFileExtensionFromUrl(fileName);
+            if (extension != null && !extension.isEmpty()) {
+                return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.toLowerCase(Locale.US));
+            }
+        }
+
+        return null;
+    }
+
+    @Nullable
+    public static String getFileName(@NonNull Context context, @NonNull Uri uri) {
+        String scheme = uri.getScheme();
+        if (ContentResolver.SCHEME_CONTENT.equals(scheme)) {
+            String displayName = queryDisplayName(context, uri);
+            if (displayName != null && !displayName.isEmpty()) {
+                return displayName;
+            }
+        }
+
+        if (ContentResolver.SCHEME_FILE.equals(scheme)) {
+            File file = new File(uri.getPath() == null ? "" : uri.getPath());
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                String mediaStoreName = queryMediaStoreDisplayName(context, uri);
+                if (mediaStoreName != null && !mediaStoreName.isEmpty()) {
+                    return mediaStoreName;
+                }
+            } else {
+                File legacyRoot = Environment.getExternalStorageDirectory();
+                String absolutePath = file.getAbsolutePath();
+                if (legacyRoot != null && absolutePath.startsWith(legacyRoot.getAbsolutePath())) {
+                    return file.getName();
+                }
+            }
+            return file.getName();
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            String mediaStoreName = queryMediaStoreDisplayName(context, uri);
+            if (mediaStoreName != null && !mediaStoreName.isEmpty()) {
+                return mediaStoreName;
+            }
+        }
+
+        String lastPathSegment = uri.getLastPathSegment();
+        if (lastPathSegment == null || lastPathSegment.isEmpty()) {
+            return null;
+        }
+
+        int slashIndex = lastPathSegment.lastIndexOf('/');
+        if (slashIndex >= 0 && slashIndex < lastPathSegment.length() - 1) {
+            return lastPathSegment.substring(slashIndex + 1);
+        }
+
+        return lastPathSegment;
+    }
+
+    @Nullable
+    private static String queryDisplayName(@NonNull Context context, @NonNull Uri uri) {
+        try (Cursor cursor = context.getContentResolver().query(
+                uri,
+                new String[]{OpenableColumns.DISPLAY_NAME},
+                null,
+                null,
+                null
+        )) {
+            if (cursor != null && cursor.moveToFirst()) {
+                int index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                if (index >= 0) {
+                    return cursor.getString(index);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    @Nullable
+    private static String queryMediaStoreDisplayName(@NonNull Context context, @NonNull Uri uri) {
+        try (Cursor cursor = context.getContentResolver().query(
+                uri,
+                new String[]{MediaStore.MediaColumns.DISPLAY_NAME},
+                null,
+                null,
+                null
+        )) {
+            if (cursor != null && cursor.moveToFirst()) {
+                int index = cursor.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME);
+                if (index >= 0) {
+                    return cursor.getString(index);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    @NonNull
+    private static File createUniqueFile(@NonNull File parent, @NonNull String fileName) {
+        File file = new File(parent, fileName);
+        if (!file.exists()) {
+            return file;
+        }
+
+        String baseName = fileName;
+        String extension = "";
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex > 0) {
+            baseName = fileName.substring(0, dotIndex);
+            extension = fileName.substring(dotIndex);
+        }
+
+        int counter = 1;
+        File candidate = file;
+        while (candidate.exists()) {
+            candidate = new File(parent, baseName + "_" + counter + extension);
+            counter++;
+        }
+        return candidate;
+    }
+
+    @NonNull
+    private static String sanitizeFileName(@NonNull String input) {
+        String sanitized = input.replaceAll("[\\\\/:*?\"<>|]", "_").trim();
+        return sanitized.isEmpty() ? "attachment_" + System.currentTimeMillis() : sanitized;
+    }
+}

--- a/app/src/main/java/com/example/ucms_android/util/NotificationHelper.java
+++ b/app/src/main/java/com/example/ucms_android/util/NotificationHelper.java
@@ -1,0 +1,82 @@
+package com.example.ucms_android.util;
+
+import android.Manifest;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+
+import com.example.ucms_android.R;
+
+public final class NotificationHelper {
+    public static final String CHANNEL_ID = "ucms_ticket_updates";
+    private static final String CHANNEL_NAME = "Ticket Updates";
+    private static final String CHANNEL_DESCRIPTION = "Notifications for ticket status changes and responses";
+
+    private NotificationHelper() {
+    }
+
+    public static void createChannel(Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+
+        NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+        if (notificationManager == null) {
+            return;
+        }
+
+        NotificationChannel channel = new NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_DEFAULT
+        );
+        channel.setDescription(CHANNEL_DESCRIPTION);
+        notificationManager.createNotificationChannel(channel);
+    }
+
+    public static void showTicketNotification(
+            Context context,
+            String title,
+            String message,
+            int notificationId
+    ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS)
+                != PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+
+        createChannel(context);
+
+        Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
+        int pendingIntentFlags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            pendingIntentFlags |= PendingIntent.FLAG_IMMUTABLE;
+        }
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentTitle(title)
+                .setContentText(message)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setAutoCancel(true);
+
+        if (launchIntent != null) {
+            builder.setContentIntent(PendingIntent.getActivity(
+                    context,
+                    notificationId,
+                    launchIntent,
+                    pendingIntentFlags
+            ));
+        }
+
+        NotificationManagerCompat.from(context).notify(notificationId, builder.build());
+    }
+}

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path
+        name="cache"
+        path="." />
+    <files-path
+        name="files"
+        path="." />
+    <external-files-path
+        name="external_files"
+        path="." />
+    <external-cache-path
+        name="external_cache"
+        path="." />
+</paths>

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -2,14 +2,14 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <cache-path
         name="cache"
-        path="." />
+        path="ticket_attachments" />
     <files-path
         name="files"
-        path="." />
+        path="ticket_attachments" />
     <external-files-path
         name="external_files"
-        path="." />
+        path="ticket_attachments" />
     <external-cache-path
         name="external_cache"
-        path="." />
+        path="ticket_attachments" />
 </paths>


### PR DESCRIPTION
## Type of Change
- [x] feat — new feature

## Labels
- p2-medium, feat, android

## What Changed
- Added  — FileProvider paths config
- Registered  in 
- Added version-aware permissions ( maxSdk=32,  +  minSdk=33)
- Created  — scoped storage file picker utility
- Created  — notification channel + push helper
- Created  — initializes notification channel on startup

## Why
Ensures UCMS Android app works correctly across Android 7.0 (API 24) to Android 14+ (API 36).

## How to Test
1. Build and run on API 24 emulator — verify no crashes
2. Test file picker on API 29+ emulator — scoped storage
3. Test notifications on API 26+ — channel should be created

## Related Issues
Closes #23

## Checklist
- [x] Code follows the Google Java Style Guide
- [x] No secrets or credentials committed
- [x] App builds and runs on API 24+
- [x] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

* **New Features**
  * Added file attachment picker functionality
  * Enabled in-app notifications with permission handling
  * Added support for password reset via deep links
  * Configured media file access permissions across Android versions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File attachment support: Users can now select and attach files from their device to tickets
  * Notification system: New ticket notifications alert users to important updates
  * Enhanced file handling with proper permission management across Android versions 12 and later

<!-- end of auto-generated comment: release notes by coderabbit.ai -->