### PR TITLE
feat: password reset via Supabase REST API

### DIFF
--- a/app/src/main/java/com/example/ucms_android/ForgotPasswordActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ForgotPasswordActivity.java
@@ -1,13 +1,113 @@
 package com.example.ucms_android;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.text.TextUtils;
+import android.util.Log;
+import android.util.Patterns;
+import android.view.View;
+import android.widget.ProgressBar;
+import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.example.ucms_android.api.request.PasswordRecoverRequest;
+import com.example.ucms_android.network.SupabaseApiClient;
+import com.example.ucms_android.network.SupabaseAuthService;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.snackbar.Snackbar;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
+
+import java.io.IOException;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
 public class ForgotPasswordActivity extends AppCompatActivity {
+
+    private static final String TAG = "ForgotPassword";
+
+    private TextInputLayout tilEmail;
+    private TextInputEditText etEmail;
+    private MaterialButton btnSendReset;
+    private TextView tvBackToLogin;
+    private ProgressBar progressBar;
+
+    private SupabaseAuthService supabaseAuthService;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_forgot_password);
+
+        tilEmail = findViewById(R.id.tilEmail);
+        etEmail = findViewById(R.id.etEmail);
+        btnSendReset = findViewById(R.id.btnSendReset);
+        tvBackToLogin = findViewById(R.id.tvBackToLogin);
+        progressBar = findViewById(R.id.progressBar);
+
+        supabaseAuthService = SupabaseApiClient.getAuthService();
+
+        btnSendReset.setOnClickListener(v -> handleSendReset());
+
+        tvBackToLogin.setOnClickListener(v -> {
+            startActivity(new Intent(this, LoginActivity.class));
+            finish();
+        });
+    }
+
+    private void handleSendReset() {
+        String email = etEmail.getText() != null ? etEmail.getText().toString().trim() : "";
+
+        tilEmail.setError(null);
+
+        if (TextUtils.isEmpty(email)) {
+            tilEmail.setError(getString(R.string.error_invalid_email));
+            return;
+        }
+
+        if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+            tilEmail.setError(getString(R.string.error_invalid_email));
+            return;
+        }
+
+        setLoading(true);
+
+        PasswordRecoverRequest request = new PasswordRecoverRequest(email, "ucms://reset-password");
+
+        supabaseAuthService.recoverPassword(SupabaseApiClient.ANON_KEY, request)
+                .enqueue(new Callback<Void>() {
+                    @Override
+                    public void onResponse(Call<Void> call, Response<Void> response) {
+                        setLoading(false);
+                        if (response.isSuccessful()) {
+                            Log.d(TAG, "Recovery email sent successfully");
+                            Snackbar.make(btnSendReset, getString(R.string.success_reset_email), Snackbar.LENGTH_LONG).show();
+                            btnSendReset.setEnabled(false);
+                        } else {
+                            try {
+                                String errorBody = response.errorBody() != null ? response.errorBody().string() : "null";
+                                Log.e(TAG, "Recovery failed - code: " + response.code() + " body: " + errorBody);
+                            } catch (IOException e) {
+                                Log.e(TAG, "Recovery failed - code: " + response.code());
+                            }
+                            Snackbar.make(btnSendReset, getString(R.string.error_reset_failed), Snackbar.LENGTH_LONG).show();
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Call<Void> call, Throwable t) {
+                        setLoading(false);
+                        Log.e(TAG, "Network failure: " + t.getMessage(), t);
+                        Snackbar.make(btnSendReset, getString(R.string.error_reset_failed), Snackbar.LENGTH_LONG).show();
+                    }
+                });
+    }
+
+    private void setLoading(boolean isLoading) {
+        progressBar.setVisibility(isLoading ? View.VISIBLE : View.GONE);
+        btnSendReset.setEnabled(!isLoading);
     }
 }

--- a/app/src/main/java/com/example/ucms_android/ForgotPasswordActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ForgotPasswordActivity.java
@@ -19,8 +19,6 @@ import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 
-import java.io.IOException;
-
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -87,12 +85,7 @@ public class ForgotPasswordActivity extends AppCompatActivity {
                             Snackbar.make(btnSendReset, getString(R.string.success_reset_email), Snackbar.LENGTH_LONG).show();
                             btnSendReset.setEnabled(false);
                         } else {
-                            try {
-                                String errorBody = response.errorBody() != null ? response.errorBody().string() : "null";
-                                Log.e(TAG, "Recovery failed - code: " + response.code() + " body: " + errorBody);
-                            } catch (IOException e) {
-                                Log.e(TAG, "Recovery failed - code: " + response.code());
-                            }
+                            Log.e(TAG, "Recovery failed - server error: " + response.code());
                             Snackbar.make(btnSendReset, getString(R.string.error_reset_failed), Snackbar.LENGTH_LONG).show();
                         }
                     }
@@ -100,7 +93,7 @@ public class ForgotPasswordActivity extends AppCompatActivity {
                     @Override
                     public void onFailure(Call<Void> call, Throwable t) {
                         setLoading(false);
-                        Log.e(TAG, "Network failure: " + t.getMessage(), t);
+                        Log.e(TAG, "Network failure during password recovery");
                         Snackbar.make(btnSendReset, getString(R.string.error_reset_failed), Snackbar.LENGTH_LONG).show();
                     }
                 });

--- a/app/src/main/java/com/example/ucms_android/ResetPasswordActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ResetPasswordActivity.java
@@ -1,0 +1,132 @@
+package com.example.ucms_android;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.ProgressBar;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.ucms_android.api.request.PasswordUpdateRequest;
+import com.example.ucms_android.network.SupabaseApiClient;
+import com.example.ucms_android.network.SupabaseAuthService;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.snackbar.Snackbar;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class ResetPasswordActivity extends AppCompatActivity {
+
+    private TextInputLayout tilNewPassword;
+    private TextInputLayout tilConfirmPassword;
+    private TextInputEditText etNewPassword;
+    private TextInputEditText etConfirmPassword;
+    private MaterialButton btnResetPassword;
+    private ProgressBar progressBar;
+
+    private SupabaseAuthService supabaseAuthService;
+    private String recoveryToken;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_reset_password);
+
+        tilNewPassword = findViewById(R.id.tilNewPassword);
+        tilConfirmPassword = findViewById(R.id.tilConfirmPassword);
+        etNewPassword = findViewById(R.id.etNewPassword);
+        etConfirmPassword = findViewById(R.id.etConfirmPassword);
+        btnResetPassword = findViewById(R.id.btnResetPassword);
+        progressBar = findViewById(R.id.progressBar);
+
+        supabaseAuthService = SupabaseApiClient.getAuthService();
+
+        // Extract recovery token from deep link
+        recoveryToken = extractRecoveryToken(getIntent());
+
+        if (recoveryToken == null) {
+            Snackbar.make(btnResetPassword, getString(R.string.error_invalid_reset_link), Snackbar.LENGTH_LONG).show();
+            btnResetPassword.setEnabled(false);
+            return;
+        }
+
+        btnResetPassword.setOnClickListener(v -> handleResetPassword());
+    }
+
+    private String extractRecoveryToken(Intent intent) {
+        if (intent == null) return null;
+        Uri data = intent.getData();
+        if (data == null) return null;
+
+        // Supabase sends token in fragment: ucms://reset-password#access_token=...
+        String fragment = data.getFragment();
+        if (fragment == null) return null;
+
+        for (String param : fragment.split("&")) {
+            if (param.startsWith("access_token=")) {
+                return param.substring("access_token=".length());
+            }
+        }
+        return null;
+    }
+
+    private void handleResetPassword() {
+        String newPassword = etNewPassword.getText() != null ? etNewPassword.getText().toString().trim() : "";
+        String confirmPassword = etConfirmPassword.getText() != null ? etConfirmPassword.getText().toString().trim() : "";
+
+        tilNewPassword.setError(null);
+        tilConfirmPassword.setError(null);
+
+        if (TextUtils.isEmpty(newPassword) || newPassword.length() < 8) {
+            tilNewPassword.setError(getString(R.string.error_password_too_short));
+            return;
+        }
+
+        if (!newPassword.equals(confirmPassword)) {
+            tilConfirmPassword.setError(getString(R.string.error_passwords_do_not_match));
+            return;
+        }
+
+        setLoading(true);
+
+        PasswordUpdateRequest request = new PasswordUpdateRequest(newPassword);
+
+        supabaseAuthService.updatePassword(
+                SupabaseApiClient.ANON_KEY,
+                "Bearer " + recoveryToken,
+                request
+        ).enqueue(new Callback<Void>() {
+            @Override
+            public void onResponse(Call<Void> call, Response<Void> response) {
+                setLoading(false);
+                if (response.isSuccessful()) {
+                    Snackbar.make(btnResetPassword, getString(R.string.success_password_reset), Snackbar.LENGTH_LONG).show();
+                    btnResetPassword.postDelayed(() -> {
+                        Intent intent = new Intent(ResetPasswordActivity.this, LoginActivity.class);
+                        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                        startActivity(intent);
+                    }, 1500);
+                } else {
+                    Snackbar.make(btnResetPassword, getString(R.string.error_password_reset_failed), Snackbar.LENGTH_LONG).show();
+                }
+            }
+
+            @Override
+            public void onFailure(Call<Void> call, Throwable t) {
+                setLoading(false);
+                Snackbar.make(btnResetPassword, getString(R.string.error_password_reset_failed), Snackbar.LENGTH_LONG).show();
+            }
+        });
+    }
+
+    private void setLoading(boolean isLoading) {
+        progressBar.setVisibility(isLoading ? View.VISIBLE : View.GONE);
+        btnResetPassword.setEnabled(!isLoading);
+    }
+}

--- a/app/src/main/java/com/example/ucms_android/ResetPasswordActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ResetPasswordActivity.java
@@ -50,7 +50,7 @@ public class ResetPasswordActivity extends AppCompatActivity {
         // Extract recovery token from deep link
         recoveryToken = extractRecoveryToken(getIntent());
 
-        if (recoveryToken == null) {
+        if (recoveryToken == null || recoveryToken.trim().isEmpty()) {
             Snackbar.make(btnResetPassword, getString(R.string.error_invalid_reset_link), Snackbar.LENGTH_LONG).show();
             btnResetPassword.setEnabled(false);
             return;

--- a/app/src/main/java/com/example/ucms_android/api/request/PasswordRecoverRequest.java
+++ b/app/src/main/java/com/example/ucms_android/api/request/PasswordRecoverRequest.java
@@ -1,0 +1,23 @@
+package com.example.ucms_android.api.request;
+
+import com.google.gson.annotations.SerializedName;
+
+public class PasswordRecoverRequest {
+    private String email;
+
+    @SerializedName("redirect_to")
+    private String redirectTo;
+
+    public PasswordRecoverRequest(String email, String redirectTo) {
+        this.email = email;
+        this.redirectTo = redirectTo;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getRedirectTo() {
+        return redirectTo;
+    }
+}

--- a/app/src/main/java/com/example/ucms_android/api/request/PasswordUpdateRequest.java
+++ b/app/src/main/java/com/example/ucms_android/api/request/PasswordUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.example.ucms_android.api.request;
+
+public class PasswordUpdateRequest {
+    private String password;
+
+    public PasswordUpdateRequest(String password) {
+        this.password = password;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/app/src/main/java/com/example/ucms_android/network/SupabaseApiClient.java
+++ b/app/src/main/java/com/example/ucms_android/network/SupabaseApiClient.java
@@ -17,7 +17,13 @@ public class SupabaseApiClient {
     public static Retrofit getInstance() {
         if (instance == null) {
             HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
-            logging.setLevel(HttpLoggingInterceptor.Level.BODY);
+            if (com.example.ucms_android.BuildConfig.DEBUG) {
+                logging.setLevel(HttpLoggingInterceptor.Level.BODY);
+            } else {
+                logging.setLevel(HttpLoggingInterceptor.Level.NONE);
+            }
+            logging.redactHeader("Authorization");
+            logging.redactHeader("Cookie");
 
             OkHttpClient client = new OkHttpClient.Builder()
                     .addInterceptor(logging)

--- a/app/src/main/java/com/example/ucms_android/network/SupabaseApiClient.java
+++ b/app/src/main/java/com/example/ucms_android/network/SupabaseApiClient.java
@@ -1,0 +1,41 @@
+package com.example.ucms_android.network;
+
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+import java.util.concurrent.TimeUnit;
+
+public class SupabaseApiClient {
+
+    private static final String BASE_URL = "https://icosjzuwekgilmmxgqwr.supabase.co/";
+    public static final String ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imljb3NqenV3ZWtnaWxtbXhncXdyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzIwMDkyNTgsImV4cCI6MjA4NzU4NTI1OH0.wXKERkACJyoudEGMpumz83zAiIg9dMoJuC5xbbhriJA";
+
+    private static Retrofit instance;
+
+    public static Retrofit getInstance() {
+        if (instance == null) {
+            HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
+            logging.setLevel(HttpLoggingInterceptor.Level.BODY);
+
+            OkHttpClient client = new OkHttpClient.Builder()
+                    .addInterceptor(logging)
+                    .connectTimeout(30, TimeUnit.SECONDS)
+                    .readTimeout(30, TimeUnit.SECONDS)
+                    .writeTimeout(30, TimeUnit.SECONDS)
+                    .build();
+
+            instance = new Retrofit.Builder()
+                    .baseUrl(BASE_URL)
+                    .client(client)
+                    .addConverterFactory(GsonConverterFactory.create())
+                    .build();
+        }
+        return instance;
+    }
+
+    public static SupabaseAuthService getAuthService() {
+        return getInstance().create(SupabaseAuthService.class);
+    }
+}

--- a/app/src/main/java/com/example/ucms_android/network/SupabaseAuthService.java
+++ b/app/src/main/java/com/example/ucms_android/network/SupabaseAuthService.java
@@ -1,0 +1,31 @@
+package com.example.ucms_android.network;
+
+import com.example.ucms_android.api.request.PasswordRecoverRequest;
+import com.example.ucms_android.api.request.PasswordUpdateRequest;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.Header;
+import retrofit2.http.Headers;
+import retrofit2.http.POST;
+import retrofit2.http.PUT;
+
+public interface SupabaseAuthService {
+
+    // Triggers password reset email
+    @Headers("Content-Type: application/json")
+    @POST("auth/v1/recover")
+    Call<Void> recoverPassword(
+            @Header("apikey") String apiKey,
+            @Body PasswordRecoverRequest body
+    );
+
+    // Updates password using recovery token
+    @Headers("Content-Type: application/json")
+    @PUT("auth/v1/user")
+    Call<Void> updatePassword(
+            @Header("apikey") String apiKey,
+            @Header("Authorization") String bearerToken,
+            @Body PasswordUpdateRequest body
+    );
+}

--- a/app/src/main/res/layout/activity_forgot_password.xml
+++ b/app/src/main/res/layout/activity_forgot_password.xml
@@ -1,10 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:padding="@dimen/screen_padding">
 
-    <!-- TODO: add views -->
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/forgot_password_title"
+        android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tvDescription"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:text="@string/forgot_password_message"
+        android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/tilEmail"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_large"
+        android:hint="@string/email_hint"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvDescription">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etEmail"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textEmailAddress" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnSendReset"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_large"
+        android:text="@string/send_reset_email"
+        app:cornerRadius="@dimen/corner_radius_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tilEmail" />
+
+    <TextView
+        android:id="@+id/tvBackToLogin"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_medium"
+        android:clickable="true"
+        android:focusable="true"
+        android:text="@string/back_to_login"
+        android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+        android:textColor="?attr/colorPrimary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btnSendReset" />
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_medium"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvBackToLogin" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/screen_padding">
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/reset_password_title"
+        android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tvDescription"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:text="@string/reset_password_message"
+        android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/tilNewPassword"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_large"
+        android:hint="@string/new_password"
+        app:endIconMode="password_toggle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvDescription">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etNewPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/tilConfirmPassword"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:hint="@string/confirm_password"
+        app:endIconMode="password_toggle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tilNewPassword">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etConfirmPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnResetPassword"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_large"
+        android:text="@string/reset_password"
+        app:cornerRadius="@dimen/corner_radius_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tilConfirmPassword" />
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_medium"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btnResetPassword" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Screen -->
+    <dimen name="screen_padding">24dp</dimen>
+
+    <!-- Spacing -->
+    <dimen name="spacing_xxlarge">32dp</dimen>
+    <dimen name="spacing_xlarge">24dp</dimen>
+    <dimen name="spacing_large">20dp</dimen>
+    <dimen name="spacing_medium">16dp</dimen>
+    <dimen name="spacing_small">12dp</dimen>
+    <dimen name="spacing_xsmall">10dp</dimen>
+
+    <!-- Corner Radius -->
+    <dimen name="corner_radius_button">50dp</dimen>
+    <dimen name="corner_radius_card">16dp</dimen>
+    <dimen name="corner_radius_badge">50dp</dimen>
+    <dimen name="corner_radius_input">8dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="course">Course</string>
     <string name="year_level">Year Level</string>
     <string name="forgot_password">Forgot Password?</string>
+    <string name="student_id_hint">Student ID e.g. 20230733-N</string>
     <string name="no_account">Don\'t have an account? Register</string>
     <string name="have_account">Already have an account? Login</string>
     <string name="email_verification_title">Verify Your Email</string>
@@ -21,4 +22,21 @@
     <string name="error_login_failed">Login failed. Check your credentials.</string>
     <string name="error_register_failed">Registration failed. Please try again.</string>
     <string name="success_register">Registered successfully. Please login.</string>
+    <string name="forgot_password_title">Forgot Password</string>
+    <string name="forgot_password_message">Enter your email address and we\'ll send you a link to reset your password.</string>
+    <string name="send_reset_email">Send Reset Email</string>
+    <string name="back_to_login">Back to Login</string>
+    <string name="success_reset_email">Reset email sent. Check your inbox.</string>
+    <string name="error_reset_failed">Failed to send reset email. Please try again.</string>
+    <string name="error_invalid_email">Please enter a valid email address.</string>
+    <string name="reset_password_title">Reset Password</string>
+    <string name="reset_password_message">Enter your new password below.</string>
+    <string name="new_password">New Password</string>
+    <string name="confirm_password">Confirm Password</string>
+    <string name="reset_password">Reset Password</string>
+    <string name="success_password_reset">Password reset successfully. Please login.</string>
+    <string name="error_password_reset_failed">Failed to reset password. Please try again.</string>
+    <string name="error_passwords_do_not_match">Passwords do not match.</string>
+    <string name="error_password_too_short">Password must be at least 8 characters.</string>
+    <string name="error_invalid_reset_link">Invalid or expired reset link.</string>
 </resources>


### PR DESCRIPTION
## Type of Change
- [x] feat — new feature

## Labels
- p1-high, feat, android

## What Changed
- Implemented  — sends recovery email via Supabase REST API
- Implemented  — extracts recovery token from deep link fragment, updates password via Supabase REST API
- Added  — separate Retrofit client for Supabase auth endpoints
- Added  — Retrofit interface for  and 
- Added  and  DTOs
- Added  layout

## Why
Implements Issue 4 (Phase 1D) — password reset flow entirely on Android via Supabase REST API. Backend is not involved.

## How to Test
1. On login screen, tap Forgot Password
2. Enter email and submit — check email for reset link
3. Click reset link — app should open ResetPasswordActivity
4. Enter new password and confirm — tap Reset Password
5. On success — should navigate to LoginActivity
6. Login with new password ✅

## Related Issues
Closes #4

## Checklist
- [x] Code follows the Google Java Style Guide
- [x] No secrets or credentials committed
- [x] Recovery token extracted from URL fragment (not query param)
- [x] Backend is not involved in reset flow
- [x] App builds and runs on API 24+
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added password recovery and reset flows: request reset by email, follow deep-link, and set a new password with validation, loading states, and success/error feedback.
  * New UI screens with input controls, toggles for password visibility, progress indicators, and navigation back to login.
* **Style**
  * Standardized spacing, paddings, and corner radii plus new user-facing strings for the authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->