### PR TITLE
fix: security hardening

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -29,5 +29,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Inject secrets into local.properties
+        run: echo "SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" >> local.properties
+
       - name: Build and run unit tests
         run: ./gradlew build

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The app reads sensitive config from `local.properties` (gitignored — never com
 
 After cloning, add the following to your `local.properties` file (in the root of the project):
 
-```
+```properties
 SUPABASE_ANON_KEY=<ask the project lead for this value>
 BACKEND_BASE_URL=http://10.0.2.2:8080/
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ cd ucms-android
 
 ---
 
+## Local Configuration
+
+The app reads sensitive config from `local.properties` (gitignored — never committed).
+
+After cloning, add the following to your `local.properties` file (in the root of the project):
+
+```
+SUPABASE_ANON_KEY=<ask the project lead for this value>
+BACKEND_BASE_URL=http://10.0.2.2:8080/
+```
+
+> ⚠️ `local.properties` must never be committed. It is already in `.gitignore`.
+> ⚠️ `BACKEND_BASE_URL` is the local emulator URL. If running on a physical device, replace `10.0.2.2` with your machine's local IP address.
+
+---
+
 ## Setup
 
 1. Open **Android Studio**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            val supabaseKey = localProperties.getProperty("SUPABASE_ANON_KEY", "")
+            check(supabaseKey.isNotBlank()) {
+                "SUPABASE_ANON_KEY must be set in local.properties for release builds"
+            }
         }
     }
     compileOptions {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,14 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
+}
+
+val localProperties = Properties().apply {
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        localPropertiesFile.inputStream().use { load(it) }
+    }
 }
 
 android {
@@ -14,6 +23,9 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField("String", "SUPABASE_ANON_KEY", "\"${localProperties.getProperty("SUPABASE_ANON_KEY", "")}\"")
+        buildConfigField("String", "BACKEND_BASE_URL", "\"${localProperties.getProperty("BACKEND_BASE_URL", "http://10.0.2.2:8080/")}\"")
     }
 
     buildTypes {
@@ -35,7 +47,6 @@ android {
 }
 
 dependencies {
-
     implementation(libs.appcompat)
     implementation(libs.material)
     implementation(libs.activity)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,10 +35,6 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            val supabaseKey = localProperties.getProperty("SUPABASE_ANON_KEY", "")
-            check(supabaseKey.isNotBlank()) {
-                "SUPABASE_ANON_KEY must be set in local.properties for release builds"
-            }
         }
     }
     compileOptions {
@@ -64,4 +60,13 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging.interceptor)
     implementation(libs.security.crypto)
+}
+
+gradle.taskGraph.whenReady {
+    if (allTasks.any { it.name.contains("Release") }) {
+        val supabaseKey = localProperties.getProperty("SUPABASE_ANON_KEY", "")
+        check(supabaseKey.isNotBlank()) {
+            "SUPABASE_ANON_KEY must be set in local.properties for release builds"
+        }
+    }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,8 +14,6 @@
     <application
         android:name=".UcmsApplication"
         android:allowBackup="false"
-        android:dataExtractionRules="@xml/data_extraction_rules"
-        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
@@ -30,6 +28,7 @@
         <activity
             android:name=".LoginActivity"
             android:exported="false" />
+        <!-- SECURITY: Token received via deep link fragment must be verified server-side before use -->
         <activity
             android:name=".ResetPasswordActivity"
             android:exported="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
 
     <application
         android:name=".UcmsApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
@@ -30,6 +30,18 @@
         <activity
             android:name=".LoginActivity"
             android:exported="false" />
+        <activity
+            android:name=".ResetPasswordActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="ucms"
+                    android:host="reset-password" />
+            </intent-filter>
+        </activity>
         <activity
             android:name=".ForgotPasswordActivity"
             android:exported="false" />

--- a/app/src/main/java/com/example/ucms_android/auth/TokenManager.java
+++ b/app/src/main/java/com/example/ucms_android/auth/TokenManager.java
@@ -2,6 +2,7 @@ package com.example.ucms_android.auth;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 
 import androidx.security.crypto.EncryptedSharedPreferences;
 import androidx.security.crypto.MasterKey;
@@ -16,8 +17,7 @@ public class TokenManager {
 
     private static TokenManager instance;
 
-    private TokenManager() {
-    }
+    private TokenManager() {}
 
     public static synchronized TokenManager getInstance() {
         if (instance == null) {
@@ -43,7 +43,12 @@ public class TokenManager {
     }
 
     public void clear(Context context) {
-        getPrefs(context).edit().clear().apply();
+        Context appContext = context.getApplicationContext();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            appContext.deleteSharedPreferences(PREFS_NAME);
+        } else {
+            getPrefs(context).edit().clear().apply();
+        }
     }
 
     public boolean hasToken(Context context) {
@@ -51,37 +56,40 @@ public class TokenManager {
         return token != null && !token.trim().isEmpty();
     }
 
+    private MasterKey buildMasterKey(Context appContext) throws GeneralSecurityException, IOException {
+        return new MasterKey.Builder(appContext)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build();
+    }
+
+    private SharedPreferences buildEncryptedPrefs(Context appContext, MasterKey masterKey)
+            throws GeneralSecurityException, IOException {
+        return EncryptedSharedPreferences.create(
+                appContext,
+                PREFS_NAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        );
+    }
+
     private SharedPreferences getPrefs(Context context) {
         Context appContext = context.getApplicationContext();
         try {
-            MasterKey masterKey = new MasterKey.Builder(appContext)
-                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                    .build();
-
-            return EncryptedSharedPreferences.create(
-                    appContext,
-                    PREFS_NAME,
-                    masterKey,
-                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            );
+            return buildEncryptedPrefs(appContext, buildMasterKey(appContext));
         } catch (GeneralSecurityException | IOException e) {
             android.util.Log.e("TokenManager", "Secure prefs corrupted, clearing and retrying", e);
-            appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit().clear().apply();
+            // Clear corrupted prefs and retry once
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                appContext.deleteSharedPreferences(PREFS_NAME);
+            } else {
+                appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit().clear().apply();
+            }
             try {
-                MasterKey masterKey = new MasterKey.Builder(appContext)
-                        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                        .build();
-                return EncryptedSharedPreferences.create(
-                        appContext,
-                        PREFS_NAME,
-                        masterKey,
-                        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-                );
+                return buildEncryptedPrefs(appContext, buildMasterKey(appContext));
             } catch (GeneralSecurityException | IOException retryException) {
-                android.util.Log.e("TokenManager", "Failed to initialize secure prefs after retry", retryException);
-                return appContext.getSharedPreferences(PREFS_NAME + "_fallback", Context.MODE_PRIVATE);
+                android.util.Log.e("TokenManager", "Failed to initialize secure prefs after retry - forcing re-auth", retryException);
+                throw new RuntimeException("Secure storage unavailable. Please log in again.", retryException);
             }
         }
     }

--- a/app/src/main/java/com/example/ucms_android/auth/TokenManager.java
+++ b/app/src/main/java/com/example/ucms_android/auth/TokenManager.java
@@ -66,7 +66,23 @@ public class TokenManager {
                     EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
             );
         } catch (GeneralSecurityException | IOException e) {
-            throw new IllegalStateException("Unable to initialize secure preferences", e);
+            android.util.Log.e("TokenManager", "Secure prefs corrupted, clearing and retrying", e);
+            appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit().clear().apply();
+            try {
+                MasterKey masterKey = new MasterKey.Builder(appContext)
+                        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                        .build();
+                return EncryptedSharedPreferences.create(
+                        appContext,
+                        PREFS_NAME,
+                        masterKey,
+                        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+                );
+            } catch (GeneralSecurityException | IOException retryException) {
+                android.util.Log.e("TokenManager", "Failed to initialize secure prefs after retry", retryException);
+                return appContext.getSharedPreferences(PREFS_NAME + "_fallback", Context.MODE_PRIVATE);
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/ucms_android/network/ApiClient.java
+++ b/app/src/main/java/com/example/ucms_android/network/ApiClient.java
@@ -2,6 +2,8 @@ package com.example.ucms_android.network;
 
 import android.content.Context;
 
+import com.example.ucms_android.BuildConfig;
+
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.OkHttpClient;
@@ -10,7 +12,7 @@ import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 public class ApiClient {
-    private static final String BASE_URL = "http://10.0.2.2:8080/";
+    private static final String BASE_URL = BuildConfig.BACKEND_BASE_URL;
     private static Retrofit retrofit;
 
     private ApiClient() {
@@ -19,7 +21,13 @@ public class ApiClient {
     public static synchronized Retrofit getInstance(Context context) {
         if (retrofit == null) {
             HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
-            loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+            if (BuildConfig.DEBUG) {
+                loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+            } else {
+                loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.NONE);
+            }
+            loggingInterceptor.redactHeader("Authorization");
+            loggingInterceptor.redactHeader("Cookie");
 
             OkHttpClient okHttpClient = new OkHttpClient.Builder()
                     .addInterceptor(new AuthInterceptor(context.getApplicationContext()))

--- a/app/src/main/java/com/example/ucms_android/network/SupabaseApiClient.java
+++ b/app/src/main/java/com/example/ucms_android/network/SupabaseApiClient.java
@@ -1,5 +1,7 @@
 package com.example.ucms_android.network;
 
+import com.example.ucms_android.BuildConfig;
+
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Retrofit;
@@ -10,14 +12,14 @@ import java.util.concurrent.TimeUnit;
 public class SupabaseApiClient {
 
     private static final String BASE_URL = "https://icosjzuwekgilmmxgqwr.supabase.co/";
-    public static final String ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imljb3NqenV3ZWtnaWxtbXhncXdyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzIwMDkyNTgsImV4cCI6MjA4NzU4NTI1OH0.wXKERkACJyoudEGMpumz83zAiIg9dMoJuC5xbbhriJA";
+    public static final String ANON_KEY = BuildConfig.SUPABASE_ANON_KEY;
 
     private static Retrofit instance;
 
     public static Retrofit getInstance() {
         if (instance == null) {
             HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
-            if (com.example.ucms_android.BuildConfig.DEBUG) {
+            if (BuildConfig.DEBUG) {
                 logging.setLevel(HttpLoggingInterceptor.Level.BODY);
             } else {
                 logging.setLevel(HttpLoggingInterceptor.Level.NONE);


### PR DESCRIPTION
## Type of Change
- [x] fix — bug fix
- [x] security — security-related fix

## Labels
- p1-high, fix, security, android

## What Changed
- Moved `SUPABASE_ANON_KEY` and `BACKEND_BASE_URL` out of source code into `local.properties` + `BuildConfig`
- `ApiClient` and `SupabaseApiClient` — debug-only HTTP logging, redact `Authorization` and `Cookie` headers
- `TokenManager` — graceful retry/fallback instead of crash on `EncryptedSharedPreferences` failure
- `AndroidManifest.xml` — `allowBackup=false`, added `ResetPasswordActivity` deep link
- `README.md` — added `local.properties` setup instructions for teammates

## Why
Addresses Critical and High severity findings from code review — prevents API key exposure, sensitive data leaking in logs, and app crashes on secure storage failure.

## How to Test
1. Build and run — verify app starts correctly
2. Verify `SUPABASE_ANON_KEY` is not visible in source code
3. Verify HTTP logs are suppressed in release build
4. Test password reset deep link opens `ResetPasswordActivity`

## Checklist
- [x] No secrets or credentials committed
- [x] `local.properties` is gitignored
- [x] App builds and runs on API 24+
- [x] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password reset via deep links (ucms://reset-password)
  * Backend URL and auth key are now configurable at build/runtime

* **Security Improvements**
  * Enhanced and more reliable encrypted storage for credentials
  * App backups disabled to protect sensitive data
  * Sensitive headers redacted and debug logging reduced in non-debug builds

* **Documentation**
  * Added local configuration guide with required environment variables and setup notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->