### PR TITLE
feat: phase 1F drawable resources (issue #25)

### DIFF
--- a/app/src/main/res/drawable/bg_button_pill.xml
+++ b/app/src/main/res/drawable/bg_button_pill.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/colorPrimary" />
+
+    <corners android:radius="@dimen/corner_radius_button" />
+
+</shape>

--- a/app/src/main/res/drawable/bg_card.xml
+++ b/app/src/main/res/drawable/bg_card.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/colorSurface" />
+
+    <corners android:radius="@dimen/corner_radius_card" />
+
+</shape>

--- a/app/src/main/res/drawable/bg_input.xml
+++ b/app/src/main/res/drawable/bg_input.xml
@@ -5,7 +5,7 @@
     <solid android:color="@color/colorBackground" />
 
     <stroke
-        android:width="1dp"
+        android:width="@dimen/stroke_width_default"
         android:color="@color/colorDivider" />
 
     <corners android:radius="@dimen/corner_radius_input" />

--- a/app/src/main/res/drawable/bg_input.xml
+++ b/app/src/main/res/drawable/bg_input.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/colorBackground" />
+
+    <stroke
+        android:width="1dp"
+        android:color="@color/colorDivider" />
+
+    <corners android:radius="@dimen/corner_radius_input" />
+
+</shape>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -16,4 +16,6 @@
     <dimen name="corner_radius_card">16dp</dimen>
     <dimen name="corner_radius_badge">50dp</dimen>
     <dimen name="corner_radius_input">8dp</dimen>
+    <!-- Stroke -->
+    <dimen name="stroke_width_default">1dp</dimen>
 </resources>


### PR DESCRIPTION
## Type of Change
- [x] feat — new feature

## Labels
- p1-high, feat, android

## What Changed
- Added  — white fill, grey border, 8dp rounded corners
- Added  — light grey fill, 16dp rounded corners
- Added  — orange fill, 50dp pill shape
- Added  to  — no hardcoded values

## Why
Implements Issue #25 (Phase 1F-2) — replaces 9-patch approach with XML shape drawables (modern Android, min API 24). All values reference @color/ and @dimen/ tokens only.

## How to Test
1. Open each drawable in Android Studio — verify preview renders correctly
2. Build and run — verify no resource errors

## Closes
Closes #25

## Checklist
- [x] No hardcoded colors or dimensions — all reference @color/ and @dimen/ tokens
- [x] No secrets committed
- [x] App builds on API 24+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced UI component styling with pill-shaped button design, rounded corner treatments for cards, and improved input field appearance with border styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->