### PR TITLE
feat: add status badge drawables for all ticket states (issue #29)

### DIFF
--- a/app/src/main/res/drawable/bg_badge_closed.xml
+++ b/app/src/main/res/drawable/bg_badge_closed.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/colorStatusClosed" />
+
+    <corners android:radius="@dimen/corner_radius_badge" />
+
+</shape>

--- a/app/src/main/res/drawable/bg_badge_inprogress.xml
+++ b/app/src/main/res/drawable/bg_badge_inprogress.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/colorStatusInProgress" />
+
+    <corners android:radius="@dimen/corner_radius_badge" />
+
+</shape>

--- a/app/src/main/res/drawable/bg_badge_pending.xml
+++ b/app/src/main/res/drawable/bg_badge_pending.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/colorStatusPending" />
+
+    <corners android:radius="@dimen/corner_radius_badge" />
+
+</shape>

--- a/app/src/main/res/drawable/bg_badge_resolved.xml
+++ b/app/src/main/res/drawable/bg_badge_resolved.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/colorStatusResolved" />
+
+    <corners android:radius="@dimen/corner_radius_badge" />
+
+</shape>


### PR DESCRIPTION
## Type of Change
- [x] feat — new feature

## Labels
<!-- priority: p2-medium | type: feat | scope: android -->

## What Changed
Adds `bg_badge_pending`, `bg_badge_inprogress`, `bg_badge_resolved`, and `bg_badge_closed` drawables.

## Why
Provides visual status indicators for tickets across the app (issue #29).

## How to Test
1. Build the app
2. Verify the drawables render correctly in Android Studio layout preview

## Related Issues
Closes #29

## Screenshots
<!-- UI change — add screenshot if available -->

## Checklist
- [x] No hardcoded dimensions — use `@dimen/` tokens
- [x] No hardcoded colors — use `@color/` tokens
- [x] CI passes