### PR TITLE
feat: student ticket detail logic — responses list + student dashboard redirect (issue #35)

### DIFF
--- a/app/src/main/java/com/example/ucms_android/model/TicketResponse.java
+++ b/app/src/main/java/com/example/ucms_android/model/TicketResponse.java
@@ -1,5 +1,23 @@
 package com.example.ucms_android.model;
 
+import com.google.gson.annotations.SerializedName;
+
 public class TicketResponse {
-    // TODO: response fields
+
+    @SerializedName("id")
+    private Long id;
+
+    @SerializedName("message")
+    private String message;
+
+    @SerializedName("adminName")
+    private String adminName;
+
+    @SerializedName("createdAt")
+    private String createdAt;
+
+    public Long getId() { return id; }
+    public String getMessage() { return message; }
+    public String getAdminName() { return adminName; }
+    public String getCreatedAt() { return createdAt; }
 }

--- a/app/src/main/java/com/example/ucms_android/ui/adapter/TicketResponseAdapter.java
+++ b/app/src/main/java/com/example/ucms_android/ui/adapter/TicketResponseAdapter.java
@@ -1,0 +1,58 @@
+package com.example.ucms_android.ui.adapter;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.ucms_android.R;
+import com.example.ucms_android.model.TicketResponse;
+
+import java.util.List;
+
+public class TicketResponseAdapter extends RecyclerView.Adapter<TicketResponseAdapter.ViewHolder> {
+
+    private List<TicketResponse> responses;
+
+    public TicketResponseAdapter(List<TicketResponse> responses) {
+        this.responses = responses;
+    }
+
+    public void updateData(List<TicketResponse> newResponses) {
+        this.responses = newResponses;
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item_response, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        TicketResponse response = responses.get(position);
+        holder.tvAdminName.setText(response.getAdminName());
+        holder.tvMessage.setText(response.getMessage());
+        holder.tvCreatedAt.setText(response.getCreatedAt());
+    }
+
+    @Override
+    public int getItemCount() { return responses.size(); }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+        TextView tvAdminName, tvMessage, tvCreatedAt;
+
+        ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            tvAdminName = itemView.findViewById(R.id.tvAdminName);
+            tvMessage = itemView.findViewById(R.id.tvMessage);
+            tvCreatedAt = itemView.findViewById(R.id.tvCreatedAt);
+        }
+    }
+}

--- a/app/src/main/java/com/example/ucms_android/ui/student/StudentDashboardActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/student/StudentDashboardActivity.java
@@ -1,7 +1,17 @@
 package com.example.ucms_android.ui.student;
 
+import android.content.Intent;
+import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
 
 public class StudentDashboardActivity extends AppCompatActivity {
-    // TODO: implement screen
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Dashboard is not yet implemented — route directly to ticket list
+        startActivity(new Intent(this, TicketListActivity.class));
+        finish();
+    }
 }

--- a/app/src/main/java/com/example/ucms_android/ui/student/TicketDetailActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/student/TicketDetailActivity.java
@@ -1,7 +1,144 @@
 package com.example.ucms_android.ui.student;
 
+import android.os.Bundle;
+import android.view.View;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.ucms_android.R;
+import com.example.ucms_android.model.Ticket;
+import com.example.ucms_android.model.TicketResponse;
+import com.example.ucms_android.network.ApiClient;
+import com.example.ucms_android.network.TicketService;
+import com.example.ucms_android.ui.adapter.TicketResponseAdapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class TicketDetailActivity extends AppCompatActivity {
-    // TODO: implement screen
+
+    private ImageButton btnBack;
+    private TextView tvTicketNumber, tvStatus, tvDate, tvTicketTitle,
+            tvDescription, tvAttachmentLabel, tvAttachmentName;
+    private ImageView ivAttachmentPreview;
+    private RecyclerView rvResponses;
+    private TicketResponseAdapter responseAdapter;
+    private TicketService ticketService;
+    private Long ticketId;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_ticket_detail);
+
+        ticketId = getIntent().getLongExtra("ticketId", -1);
+        if (ticketId == -1) { finish(); return; }
+
+        bindViews();
+
+        ticketService = ApiClient.getInstance(this).create(TicketService.class);
+
+        btnBack.setOnClickListener(v -> finish());
+
+        responseAdapter = new TicketResponseAdapter(new ArrayList<>());
+        rvResponses.setLayoutManager(new LinearLayoutManager(this));
+        rvResponses.setAdapter(responseAdapter);
+
+        loadTicket();
+        loadResponses();
+    }
+
+    private void bindViews() {
+        btnBack = findViewById(R.id.btnBack);
+        tvTicketNumber = findViewById(R.id.tvTicketNumber);
+        tvStatus = findViewById(R.id.tvStatus);
+        tvDate = findViewById(R.id.tvDate);
+        tvTicketTitle = findViewById(R.id.tvTicketTitle);
+        tvDescription = findViewById(R.id.tvDescription);
+        tvAttachmentLabel = findViewById(R.id.tvAttachmentLabel);
+        tvAttachmentName = findViewById(R.id.tvAttachmentName);
+        ivAttachmentPreview = findViewById(R.id.ivAttachmentPreview);
+        rvResponses = findViewById(R.id.rvResponses);
+    }
+
+    private void loadTicket() {
+        ticketService.getTicketById(ticketId).enqueue(new Callback<Ticket>() {
+            @Override
+            public void onResponse(Call<Ticket> call, Response<Ticket> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    populateViews(response.body());
+                } else {
+                    Toast.makeText(TicketDetailActivity.this,
+                            getString(R.string.error_loading_tickets), Toast.LENGTH_SHORT).show();
+                    finish();
+                }
+            }
+
+            @Override
+            public void onFailure(Call<Ticket> call, Throwable t) {
+                Toast.makeText(TicketDetailActivity.this,
+                        getString(R.string.error_network), Toast.LENGTH_SHORT).show();
+                finish();
+            }
+        });
+    }
+
+    private void populateViews(Ticket ticket) {
+        tvTicketNumber.setText(ticket.getTicketNumber());
+        tvStatus.setText(ticket.getStatus());
+        tvDate.setText(ticket.getCreatedAt());
+        tvTicketTitle.setText(ticket.getTitle());
+        tvDescription.setText(ticket.getDescription());
+        tvStatus.setBackground(getStatusDrawable(ticket.getStatus()));
+
+        if (ticket.getAttachmentName() != null && !ticket.getAttachmentName().isEmpty()) {
+            tvAttachmentName.setText(ticket.getAttachmentName());
+            tvAttachmentName.setVisibility(View.VISIBLE);
+            ivAttachmentPreview.setVisibility(View.VISIBLE);
+        } else {
+            tvAttachmentLabel.setVisibility(View.GONE);
+            ivAttachmentPreview.setVisibility(View.GONE);
+            tvAttachmentName.setVisibility(View.GONE);
+        }
+    }
+
+    private void loadResponses() {
+        ticketService.getTicketResponses(ticketId).enqueue(new Callback<List<TicketResponse>>() {
+            @Override
+            public void onResponse(Call<List<TicketResponse>> call, Response<List<TicketResponse>> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    responseAdapter.updateData(response.body());
+                }
+            }
+
+            @Override
+            public void onFailure(Call<List<TicketResponse>> call, Throwable t) {
+                // Silently fail — responses are supplementary
+            }
+        });
+    }
+
+    private android.graphics.drawable.Drawable getStatusDrawable(String status) {
+        int drawableRes;
+        if ("PENDING".equalsIgnoreCase(status)) {
+            drawableRes = R.drawable.bg_badge_pending;
+        } else if ("IN_PROGRESS".equalsIgnoreCase(status)) {
+            drawableRes = R.drawable.bg_badge_inprogress;
+        } else if ("RESOLVED".equalsIgnoreCase(status)) {
+            drawableRes = R.drawable.bg_badge_resolved;
+        } else {
+            drawableRes = R.drawable.bg_badge_closed;
+        }
+        return getDrawable(drawableRes);
+    }
 }

--- a/app/src/main/res/layout/item_response.xml
+++ b/app/src/main/res/layout/item_response.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/spacing_small"
+    app:cardBackgroundColor="@color/colorBackground"
+    app:cardCornerRadius="@dimen/corner_radius_card"
+    app:cardElevation="2dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/spacing_medium">
+
+        <TextView
+            android:id="@+id/tvAdminName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+            android:textColor="@color/colorTextPrimary"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@id/tvCreatedAt"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Admin User" />
+
+        <TextView
+            android:id="@+id/tvCreatedAt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            android:textColor="@color/colorTextSecondary"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="2 mins ago" />
+
+        <TextView
+            android:id="@+id/tvMessage"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_xsmall"
+            android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+            android:textColor="@color/colorTextPrimary"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tvAdminName"
+            tools:text="We have resolved your concern. Please confirm if the issue has been addressed." />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
## Type of Change
- [x] feat — new feature

## Labels
<!-- priority: p2-medium | type: feat | scope: android -->

## What Changed
Implements `TicketDetailActivity`, `TicketResponseAdapter`, `StudentDashboardActivity` redirect, and `item_response.xml`.

## Why
Wires up the logic for viewing ticket details and responses (issue #35).

## How to Test
1. Build and run the app
2. Log in as student and open a ticket to view details

## Related Issues
Closes #35

## Checklist
- [x] Code follows the Google Java Style Guide
- [x] CI passes