### PR TITLE
feat: refactor bottom nav to fragment-based navigation, hide analytics for students

### DIFF
--- a/app/src/main/java/com/example/ucms_android/ui/admin/AdminDashboardFragment.java
+++ b/app/src/main/java/com/example/ucms_android/ui/admin/AdminDashboardFragment.java
@@ -1,0 +1,147 @@
+package com.example.ucms_android.ui.admin;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.ucms_android.R;
+import com.example.ucms_android.model.Ticket;
+import com.example.ucms_android.network.ApiClient;
+import com.example.ucms_android.network.TicketService;
+import com.example.ucms_android.ui.adapter.RecentTicketAdapter;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class AdminDashboardFragment extends Fragment {
+
+    private TextView tvTotalTickets;
+    private TextView tvPendingCount;
+    private TextView tvResolvedCount;
+    private TextView tvViewDatabase;
+    private RecyclerView rvRecentTickets;
+    private RecentTicketAdapter adapter;
+    private TicketService ticketService;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_admin_dashboard, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        tvTotalTickets = view.findViewById(R.id.tvTotalTickets);
+        tvPendingCount = view.findViewById(R.id.tvPendingCount);
+        tvResolvedCount = view.findViewById(R.id.tvResolvedCount);
+        tvViewDatabase = view.findViewById(R.id.tvViewDatabase);
+        rvRecentTickets = view.findViewById(R.id.rvRecentTickets);
+
+        ticketService = ApiClient.getInstance(requireContext()).create(TicketService.class);
+
+        adapter = new RecentTicketAdapter(new ArrayList<>(), ticket -> {
+            Intent intent = new Intent(requireActivity(), AdminTicketDetailActivity.class);
+            intent.putExtra("ticketId", ticket.getId());
+            startActivity(intent);
+        });
+        rvRecentTickets.setLayoutManager(new LinearLayoutManager(requireContext()));
+        rvRecentTickets.setAdapter(adapter);
+
+        tvViewDatabase.setOnClickListener(v -> {
+            BottomNavigationView bottomNavView = requireActivity().findViewById(R.id.bottomNavView);
+            bottomNavView.setSelectedItemId(R.id.nav_tickets);
+        });
+
+        loadTickets();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        loadTickets();
+    }
+
+    private void loadTickets() {
+        ticketService.getTickets().enqueue(new Callback<List<Ticket>>() {
+            @Override
+            public void onResponse(@NonNull Call<List<Ticket>> call,
+                                   @NonNull Response<List<Ticket>> response) {
+                if (!isAdded()) {
+                    return;
+                }
+                requireActivity().runOnUiThread(() -> {
+                    if (response.isSuccessful() && response.body() != null) {
+                        List<Ticket> tickets = response.body();
+                        updateStats(tickets);
+                        updateRecentList(tickets);
+                    } else {
+                        Toast.makeText(requireContext(),
+                                getString(R.string.error_loading_tickets),
+                                Toast.LENGTH_SHORT).show();
+                    }
+                });
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<List<Ticket>> call, @NonNull Throwable t) {
+                if (!isAdded()) {
+                    return;
+                }
+                requireActivity().runOnUiThread(() ->
+                        Toast.makeText(requireContext(),
+                                getString(R.string.error_network),
+                                Toast.LENGTH_SHORT).show());
+            }
+        });
+    }
+
+    private void updateStats(List<Ticket> tickets) {
+        int total = tickets.size();
+        int pending = 0;
+        int resolvedToday = 0;
+
+        for (Ticket ticket : tickets) {
+            if ("PENDING".equalsIgnoreCase(ticket.getStatus())) {
+                pending++;
+            }
+            if ("RESOLVED".equalsIgnoreCase(ticket.getStatus())) {
+                resolvedToday++;
+            }
+        }
+
+        tvTotalTickets.setText(String.valueOf(total));
+        tvPendingCount.setText(String.valueOf(pending));
+        tvResolvedCount.setText(String.valueOf(resolvedToday));
+    }
+
+    private void updateRecentList(List<Ticket> tickets) {
+        List<Ticket> pending = new ArrayList<>();
+        for (Ticket ticket : tickets) {
+            if ("PENDING".equalsIgnoreCase(ticket.getStatus())) {
+                pending.add(ticket);
+                if (pending.size() == 5) {
+                    break;
+                }
+            }
+        }
+        adapter.updateData(pending);
+    }
+}

--- a/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketListFragment.java
+++ b/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketListFragment.java
@@ -1,0 +1,169 @@
+package com.example.ucms_android.ui.admin;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.ucms_android.R;
+import com.example.ucms_android.model.Ticket;
+import com.example.ucms_android.network.ApiClient;
+import com.example.ucms_android.network.TicketService;
+import com.example.ucms_android.ui.adapter.TicketAdapter;
+import com.google.android.material.chip.Chip;
+import com.google.android.material.textfield.TextInputEditText;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class AdminTicketListFragment extends Fragment {
+
+    private TextInputEditText etSearch;
+    private Chip chipNeedsAction;
+    private Chip chipInProgress;
+    private Chip chipAll;
+    private RecyclerView rvTickets;
+    private TicketAdapter adapter;
+    private TicketService ticketService;
+
+    private List<Ticket> allTickets = new ArrayList<>();
+    private String activeFilter = "ALL";
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_admin_ticket_list, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        etSearch = view.findViewById(R.id.etSearch);
+        chipNeedsAction = view.findViewById(R.id.chipNeedsAction);
+        chipInProgress = view.findViewById(R.id.chipInProgress);
+        chipAll = view.findViewById(R.id.chipAll);
+        rvTickets = view.findViewById(R.id.rvTickets);
+
+        ticketService = ApiClient.getInstance(requireContext()).create(TicketService.class);
+
+        adapter = new TicketAdapter(new ArrayList<>(), ticket -> {
+            Intent intent = new Intent(requireActivity(), AdminTicketDetailActivity.class);
+            intent.putExtra("ticketId", ticket.getId());
+            startActivity(intent);
+        });
+        rvTickets.setLayoutManager(new LinearLayoutManager(requireContext()));
+        rvTickets.setAdapter(adapter);
+
+        setupChips();
+        setupSearch();
+        loadTickets();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        loadTickets();
+    }
+
+    private void setupChips() {
+        chipAll.setOnClickListener(v -> {
+            activeFilter = "ALL";
+            applyFilter();
+        });
+        chipNeedsAction.setOnClickListener(v -> {
+            activeFilter = "PENDING";
+            applyFilter();
+        });
+        chipInProgress.setOnClickListener(v -> {
+            activeFilter = "IN_PROGRESS";
+            applyFilter();
+        });
+    }
+
+    private void setupSearch() {
+        etSearch.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                applyFilter();
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+            }
+        });
+    }
+
+    private void loadTickets() {
+        ticketService.getTickets().enqueue(new Callback<List<Ticket>>() {
+            @Override
+            public void onResponse(@NonNull Call<List<Ticket>> call,
+                                   @NonNull Response<List<Ticket>> response) {
+                if (!isAdded()) {
+                    return;
+                }
+                requireActivity().runOnUiThread(() -> {
+                    if (response.isSuccessful() && response.body() != null) {
+                        allTickets = response.body();
+                        applyFilter();
+                    } else {
+                        Toast.makeText(requireContext(),
+                                getString(R.string.error_loading_tickets),
+                                Toast.LENGTH_SHORT).show();
+                    }
+                });
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<List<Ticket>> call, @NonNull Throwable t) {
+                if (!isAdded()) {
+                    return;
+                }
+                requireActivity().runOnUiThread(() ->
+                        Toast.makeText(requireContext(),
+                                getString(R.string.error_network),
+                                Toast.LENGTH_SHORT).show());
+            }
+        });
+    }
+
+    private void applyFilter() {
+        String query = etSearch.getText() != null
+                ? etSearch.getText().toString().toLowerCase().trim() : "";
+        List<Ticket> filtered = new ArrayList<>();
+
+        for (Ticket ticket : allTickets) {
+            boolean matchesFilter = activeFilter.equals("ALL")
+                    || activeFilter.equalsIgnoreCase(ticket.getStatus());
+            boolean matchesSearch = query.isEmpty()
+                    || (ticket.getTitle() != null && ticket.getTitle().toLowerCase().contains(query))
+                    || (ticket.getTicketNumber() != null
+                    && ticket.getTicketNumber().toLowerCase().contains(query));
+
+            if (matchesFilter && matchesSearch) {
+                filtered.add(ticket);
+            }
+        }
+
+        adapter.updateData(filtered);
+    }
+}

--- a/app/src/main/java/com/example/ucms_android/ui/common/AnalyticsFragment.java
+++ b/app/src/main/java/com/example/ucms_android/ui/common/AnalyticsFragment.java
@@ -1,0 +1,21 @@
+package com.example.ucms_android.ui.common;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.example.ucms_android.R;
+
+public class AnalyticsFragment extends Fragment {
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_placeholder, container, false);
+    }
+}

--- a/app/src/main/java/com/example/ucms_android/ui/common/SettingsFragment.java
+++ b/app/src/main/java/com/example/ucms_android/ui/common/SettingsFragment.java
@@ -1,0 +1,21 @@
+package com.example.ucms_android.ui.common;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.example.ucms_android.R;
+
+public class SettingsFragment extends Fragment {
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_placeholder, container, false);
+    }
+}

--- a/app/src/main/java/com/example/ucms_android/ui/student/TicketListFragment.java
+++ b/app/src/main/java/com/example/ucms_android/ui/student/TicketListFragment.java
@@ -1,0 +1,115 @@
+package com.example.ucms_android.ui.student;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.ucms_android.R;
+import com.example.ucms_android.model.Ticket;
+import com.example.ucms_android.network.ApiClient;
+import com.example.ucms_android.network.TicketService;
+import com.example.ucms_android.ui.adapter.TicketAdapter;
+import com.google.android.material.button.MaterialButton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class TicketListFragment extends Fragment {
+
+    private TextView tvEmptyState;
+    private RecyclerView rvTickets;
+    private MaterialButton btnSubmitTicket;
+    private TicketAdapter adapter;
+    private TicketService ticketService;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_ticket_list, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        tvEmptyState = view.findViewById(R.id.tvEmptyState);
+        rvTickets = view.findViewById(R.id.rvTickets);
+        btnSubmitTicket = view.findViewById(R.id.btnSubmitTicket);
+
+        ticketService = ApiClient.getInstance(requireContext()).create(TicketService.class);
+
+        adapter = new TicketAdapter(new ArrayList<>(), ticket -> {
+            Intent intent = new Intent(requireActivity(), TicketDetailActivity.class);
+            intent.putExtra("ticketId", ticket.getId());
+            startActivity(intent);
+        });
+        rvTickets.setLayoutManager(new LinearLayoutManager(requireContext()));
+        rvTickets.setAdapter(adapter);
+
+        btnSubmitTicket.setOnClickListener(v ->
+                startActivity(new Intent(requireActivity(), SubmitTicketActivity.class)));
+
+        loadTickets();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        loadTickets();
+    }
+
+    private void loadTickets() {
+        ticketService.getTickets().enqueue(new Callback<List<Ticket>>() {
+            @Override
+            public void onResponse(@NonNull Call<List<Ticket>> call,
+                                   @NonNull Response<List<Ticket>> response) {
+                if (!isAdded()) {
+                    return;
+                }
+                requireActivity().runOnUiThread(() -> {
+                    if (response.isSuccessful() && response.body() != null) {
+                        List<Ticket> tickets = response.body();
+                        if (tickets.isEmpty()) {
+                            rvTickets.setVisibility(View.GONE);
+                            tvEmptyState.setVisibility(View.VISIBLE);
+                        } else {
+                            rvTickets.setVisibility(View.VISIBLE);
+                            tvEmptyState.setVisibility(View.GONE);
+                            adapter.updateData(tickets);
+                        }
+                    } else {
+                        Toast.makeText(requireContext(),
+                                getString(R.string.error_loading_tickets),
+                                Toast.LENGTH_SHORT).show();
+                    }
+                });
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<List<Ticket>> call, @NonNull Throwable t) {
+                if (!isAdded()) {
+                    return;
+                }
+                requireActivity().runOnUiThread(() ->
+                        Toast.makeText(requireContext(),
+                                getString(R.string.error_network),
+                                Toast.LENGTH_SHORT).show());
+            }
+        });
+    }
+}

--- a/app/src/main/res/layout/fragment_admin_dashboard.xml
+++ b/app/src/main/res/layout/fragment_admin_dashboard.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorSurface"
+    android:padding="@dimen/screen_padding"
+    tools:context=".AdminDashboardActivity">
+
+    <!-- Header: Avatar -->
+    <ImageView
+        android:id="@+id/ivAvatar"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:contentDescription="@string/admin_avatar"
+        android:src="@android:drawable/ic_menu_myplaces"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- Header: Welcome text -->
+    <TextView
+        android:id="@+id/tvWelcome"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/spacing_small"
+        android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+        android:textColor="@color/colorTextPrimary"
+        app:layout_constraintBottom_toBottomOf="@id/ivAvatar"
+        app:layout_constraintEnd_toStartOf="@id/ivNotification"
+        app:layout_constraintStart_toEndOf="@id/ivAvatar"
+        app:layout_constraintTop_toTopOf="@id/ivAvatar"
+        tools:text="Welcome, Admin User" />
+
+    <!-- Header: Notification bell -->
+    <ImageView
+        android:id="@+id/ivNotification"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:contentDescription="@string/notifications"
+        android:src="@android:drawable/ic_dialog_info"
+        app:layout_constraintBottom_toBottomOf="@id/ivAvatar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/ivAvatar" />
+
+    <!-- Total Tickets Card -->
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cvTotalTickets"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_xlarge"
+        app:cardBackgroundColor="@color/colorSecondary"
+        app:cardCornerRadius="@dimen/corner_radius_card"
+        app:cardElevation="2dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ivAvatar">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_medium">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/total_tickets_label"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                android:textColor="@color/colorOnSecondary" />
+
+            <TextView
+                android:id="@+id/tvTotalTickets"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.Material3.HeadlineLarge"
+                android:textColor="@color/colorOnSecondary"
+                android:textStyle="bold"
+                tools:text="128" />
+
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+
+    <!-- Stat Cards Row -->
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cvPending"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_medium"
+        android:layout_marginEnd="@dimen/spacing_small"
+        app:cardBackgroundColor="@color/colorBackground"
+        app:cardCornerRadius="@dimen/corner_radius_card"
+        app:cardElevation="2dp"
+        app:layout_constraintEnd_toStartOf="@id/cvResolved"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/cvTotalTickets">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_medium">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/pending_label"
+                android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                android:textColor="@color/colorTextSecondary" />
+
+            <TextView
+                android:id="@+id/tvPendingCount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
+                android:textColor="@color/colorPrimary"
+                android:textStyle="bold"
+                tools:text="24" />
+
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cvResolved"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_medium"
+        android:layout_marginStart="@dimen/spacing_small"
+        app:cardBackgroundColor="@color/colorBackground"
+        app:cardCornerRadius="@dimen/corner_radius_card"
+        app:cardElevation="2dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/cvPending"
+        app:layout_constraintTop_toBottomOf="@id/cvTotalTickets">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_medium">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/resolved_today_label"
+                android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                android:textColor="@color/colorTextSecondary" />
+
+            <TextView
+                android:id="@+id/tvResolvedCount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
+                android:textColor="@color/colorSecondary"
+                android:textStyle="bold"
+                tools:text="10" />
+
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+
+    <!-- Recent Pending Concerns header -->
+    <TextView
+        android:id="@+id/tvRecentTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_xlarge"
+        android:text="@string/recent_pending_label"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+        android:textColor="@color/colorTextPrimary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/cvPending" />
+
+    <TextView
+        android:id="@+id/tvViewDatabase"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true"
+        android:text="@string/view_database"
+        android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+        android:textColor="?attr/colorPrimary"
+        app:layout_constraintBottom_toBottomOf="@id/tvRecentTitle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tvRecentTitle" />
+
+    <!-- Recent Tickets RecyclerView -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvRecentTickets"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="@dimen/spacing_small"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvRecentTitle"
+        tools:listitem="@layout/item_recent_ticket" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_admin_ticket_list.xml
+++ b/app/src/main/res/layout/fragment_admin_ticket_list.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorSurface"
+    android:padding="@dimen/screen_padding"
+    tools:context=".AdminTicketListActivity">
+
+    <!-- Search bar + filter button row -->
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/tilSearch"
+        style="@style/Style.TextInput"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="@string/search_hint"
+        app:layout_constraintEnd_toStartOf="@id/btnFilter"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etSearch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text"
+            android:maxLines="1" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <ImageButton
+        android:id="@+id/btnFilter"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="@dimen/spacing_small"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/filter"
+        android:src="@android:drawable/ic_menu_sort_by_size"
+        app:layout_constraintBottom_toBottomOf="@id/tilSearch"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tilSearch" />
+
+    <!-- Filter chips -->
+    <HorizontalScrollView
+        android:id="@+id/chipScrollView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:scrollbars="none"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tilSearch">
+
+        <com.google.android.material.chip.ChipGroup
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:singleSelection="true">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chipNeedsAction"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/chip_needs_action"
+                style="@style/Widget.Material3.Chip.Filter" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chipInProgress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/chip_in_progress"
+                style="@style/Widget.Material3.Chip.Filter" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chipAll"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/chip_all"
+                android:checked="true"
+                style="@style/Widget.Material3.Chip.Filter" />
+
+        </com.google.android.material.chip.ChipGroup>
+
+    </HorizontalScrollView>
+
+    <!-- Ticket list -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvTickets"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="@dimen/spacing_small"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/chipScrollView"
+        tools:listitem="@layout/item_ticket" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_placeholder.xml
+++ b/app/src/main/res/layout/fragment_placeholder.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorSurface">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Coming soon"
+        android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
+        android:textColor="@color/colorTextSecondary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_ticket_list.xml
+++ b/app/src/main/res/layout/fragment_ticket_list.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorSurface"
+    android:padding="@dimen/screen_padding"
+    tools:context=".TicketListActivity">
+
+    <!-- Screen title -->
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/my_tickets_title"
+        android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
+        android:textColor="@color/colorTextPrimary"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- Ticket list -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvTickets"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="@dimen/spacing_medium"
+        app:layout_constraintBottom_toTopOf="@id/btnSubmitTicket"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle"
+        tools:listitem="@layout/item_ticket" />
+
+    <!-- Empty state -->
+    <TextView
+        android:id="@+id/tvEmptyState"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/no_tickets_yet"
+        android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+        android:textColor="@color/colorTextSecondary"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/btnSubmitTicket"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle"
+        tools:visibility="visible" />
+
+    <!-- Submit ticket button -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnSubmitTicket"
+        style="@style/Style.Button.Primary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_medium"
+        android:text="@string/submit_ticket"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Type of Change
- [x] refactor — code change that neither fixes a bug nor adds a feature
- [x] feat — new feature

## Labels
<!-- priority: p2-medium | type: refactor | scope: android -->

## What Changed
Adds all fragments (`TicketListFragment`, `AdminDashboardFragment`, `AdminTicketListFragment`, `AnalyticsFragment`, `SettingsFragment`) and fragment layouts. Hides analytics tab for student role.

## Why
Refactors navigation to use Fragments instead of Activities to keep the bottom nav bar visible across screens.

## How to Test
1. Build and run the app
2. Log in and navigate between tabs
3. Verify the bottom nav bar remains visible

## Checklist
- [x] Code follows the Google Java Style Guide
- [x] CI passes