### PR TITLE
docs: add dev-setup guide and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ BACKEND_BASE_URL=http://10.0.2.2:8080/
 ```
 
 > ⚠️ `local.properties` must never be committed. It is already in `.gitignore`.
-> ⚠️ `BACKEND_BASE_URL` is the local emulator URL. If running on a physical device, replace `10.0.2.2` with your machine's local IP address.
+> ⚠️ `BACKEND_BASE_URL` is the local emulator URL. If running on a physical device, see [`docs/dev-setup.md`](docs/dev-setup.md) for instructions.
 
 ---
 
@@ -73,6 +73,7 @@ BACKEND_BASE_URL=http://10.0.2.2:8080/
 |-----|------|-------------|
 | Design System | [`docs/design-system.md`](docs/design-system.md) | Colors, dimensions, theme setup, and layout guidelines — **read before touching any layout or resource file** |
 | API Contract | [`docs/api-contract.md`](docs/api-contract.md) | All backend endpoints, request/response shapes |
+| Dev Setup | [`docs/dev-setup.md`](docs/dev-setup.md) | Local configuration, backend URL setup for emulator and real device |
 | Roles & Permissions | [`docs/roles-permissions.md`](docs/roles-permissions.md) | Student vs Admin rules, ownership checks |
 | Ticket Status Flow | [`docs/ticket-status-flow.md`](docs/ticket-status-flow.md) | Valid ticket status transitions |
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,45 @@
+# UCMS Android — Local Development Setup
+
+> This doc covers how to configure the app for local development and testing on a real device.
+
+---
+
+## Backend Base URL
+
+### Emulator
+- Use `http://10.0.2.2:8080/` — this is the Android emulator's alias for the host machine's localhost.
+
+### Real Device
+- Your phone and development machine must be on the **same WiFi network**.
+- Find your machine's local IP:
+  ```bash
+  hostname -I
+  ```
+  Use the first IP in the output (e.g. `192.168.1.9`).
+- Set in `local.properties`:
+  ```
+  BACKEND_BASE_URL=http://<your-local-ip>:8080/
+  ```
+  Example:
+  ```
+  BACKEND_BASE_URL=http://192.168.1.9:8080/
+  ```
+
+> ⚠️ `local.properties` is gitignored — never commit it.
+
+---
+
+## local.properties Template
+
+```
+BACKEND_BASE_URL=http://10.0.2.2:8080/
+SUPABASE_ANON_KEY=your_supabase_anon_key_here
+```
+
+> Get `SUPABASE_ANON_KEY` from the project lead or Supabase dashboard.
+
+---
+
+## Notes
+- Switch `BACKEND_BASE_URL` back to `http://10.0.2.2:8080/` when testing on emulator.
+- Do not hardcode IPs in source files — always use `local.properties`.


### PR DESCRIPTION
## Type of Change
- [x] docs — documentation only

## Labels
<!-- priority: p3-low | type: docs | scope: android -->

## What Changed
Adds `docs/dev-setup.md` covering real device IP setup, `local.properties` config, and backend run command. Links from `README.md`.

## Why
Improves developer onboarding and documents local testing requirements.

## How to Test
1. Read the documentation
2. Verify instructions are accurate

## Checklist
- [x] CI passes