### PR TITLE
fix: unwrap ApiResponse<T> in all ticket and category service calls

### DIFF
--- a/app/src/main/java/com/example/ucms_android/network/CategoryService.java
+++ b/app/src/main/java/com/example/ucms_android/network/CategoryService.java
@@ -1,5 +1,6 @@
 package com.example.ucms_android.network;
 
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.Category;
 
 import java.util.List;
@@ -10,5 +11,5 @@ import retrofit2.http.GET;
 public interface CategoryService {
 
     @GET("api/categories")
-    Call<List<Category>> getCategories();
+    Call<ApiResponse<List<Category>>> getCategories();
 }

--- a/app/src/main/java/com/example/ucms_android/network/TicketService.java
+++ b/app/src/main/java/com/example/ucms_android/network/TicketService.java
@@ -1,5 +1,6 @@
 package com.example.ucms_android.network;
 
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.StatusUpdateRequest;
 import com.example.ucms_android.model.Ticket;
 import com.example.ucms_android.model.TicketRequest;
@@ -18,20 +19,17 @@ import retrofit2.http.Query;
 public interface TicketService {
 
     @GET("api/tickets")
-    Call<List<Ticket>> getTickets();
-
-    @GET("api/tickets")
-    Call<List<Ticket>> getTicketsByStatus(@Query("status") String status);
+    Call<ApiResponse<List<Ticket>>> getTickets(@Query("status") String status);
 
     @GET("api/tickets/{id}")
-    Call<Ticket> getTicketById(@Path("id") Long id);
+    Call<ApiResponse<Ticket>> getTicketById(@Path("id") Long id);
 
     @POST("api/tickets")
-    Call<Ticket> createTicket(@Body TicketRequest request);
+    Call<ApiResponse<Ticket>> createTicket(@Body TicketRequest request);
 
     @PATCH("api/tickets/{id}/status")
-    Call<Ticket> updateTicketStatus(@Path("id") Long id, @Body StatusUpdateRequest request);
+    Call<ApiResponse<Ticket>> updateTicketStatus(@Path("id") Long id, @Body StatusUpdateRequest request);
 
     @GET("api/tickets/{id}/responses")
-    Call<List<TicketResponse>> getTicketResponses(@Path("id") Long id);
+    Call<ApiResponse<List<TicketResponse>>> getTicketResponses(@Path("id") Long id);
 }

--- a/app/src/main/java/com/example/ucms_android/ui/admin/AdminDashboardActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/admin/AdminDashboardActivity.java
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.ucms_android.R;
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.Ticket;
 import com.example.ucms_android.network.ApiClient;
 import com.example.ucms_android.network.TicketService;
@@ -63,11 +64,11 @@ public class AdminDashboardActivity extends AppCompatActivity {
     }
 
     private void loadTickets() {
-        ticketService.getTickets().enqueue(new Callback<List<Ticket>>() {
+        ticketService.getTickets(null).enqueue(new Callback<ApiResponse<List<Ticket>>>() {
             @Override
-            public void onResponse(Call<List<Ticket>> call, Response<List<Ticket>> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    List<Ticket> tickets = response.body();
+            public void onResponse(Call<ApiResponse<List<Ticket>>> call, Response<ApiResponse<List<Ticket>>> response) {
+                if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                    List<Ticket> tickets = response.body().getData();
                     updateStats(tickets);
                     updateRecentList(tickets);
                 } else {
@@ -77,7 +78,7 @@ public class AdminDashboardActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onFailure(Call<List<Ticket>> call, Throwable t) {
+            public void onFailure(Call<ApiResponse<List<Ticket>>> call, Throwable t) {
                 Toast.makeText(AdminDashboardActivity.this,
                         getString(R.string.error_network), Toast.LENGTH_SHORT).show();
             }

--- a/app/src/main/java/com/example/ucms_android/ui/admin/AdminDashboardFragment.java
+++ b/app/src/main/java/com/example/ucms_android/ui/admin/AdminDashboardFragment.java
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.ucms_android.R;
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.Ticket;
 import com.example.ucms_android.network.ApiClient;
 import com.example.ucms_android.network.TicketService;
@@ -80,16 +81,16 @@ public class AdminDashboardFragment extends Fragment {
     }
 
     private void loadTickets() {
-        ticketService.getTickets().enqueue(new Callback<List<Ticket>>() {
+        ticketService.getTickets(null).enqueue(new Callback<ApiResponse<List<Ticket>>>() {
             @Override
-            public void onResponse(@NonNull Call<List<Ticket>> call,
-                                   @NonNull Response<List<Ticket>> response) {
+            public void onResponse(@NonNull Call<ApiResponse<List<Ticket>>> call,
+                                   @NonNull Response<ApiResponse<List<Ticket>>> response) {
                 if (!isAdded()) {
                     return;
                 }
                 requireActivity().runOnUiThread(() -> {
-                    if (response.isSuccessful() && response.body() != null) {
-                        List<Ticket> tickets = response.body();
+                    if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                        List<Ticket> tickets = response.body().getData();
                         updateStats(tickets);
                         updateRecentList(tickets);
                     } else {
@@ -101,7 +102,7 @@ public class AdminDashboardFragment extends Fragment {
             }
 
             @Override
-            public void onFailure(@NonNull Call<List<Ticket>> call, @NonNull Throwable t) {
+            public void onFailure(@NonNull Call<ApiResponse<List<Ticket>>> call, @NonNull Throwable t) {
                 if (!isAdded()) {
                     return;
                 }

--- a/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketDetailActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketDetailActivity.java
@@ -12,6 +12,7 @@ import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.ucms_android.R;
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.StatusUpdateRequest;
 import com.example.ucms_android.model.Ticket;
 import com.example.ucms_android.network.ApiClient;
@@ -84,11 +85,11 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
     }
 
     private void loadTicket() {
-        ticketService.getTicketById(ticketId).enqueue(new Callback<Ticket>() {
+        ticketService.getTicketById(ticketId).enqueue(new Callback<ApiResponse<Ticket>>() {
             @Override
-            public void onResponse(Call<Ticket> call, Response<Ticket> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    populateViews(response.body());
+            public void onResponse(Call<ApiResponse<Ticket>> call, Response<ApiResponse<Ticket>> response) {
+                if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                    populateViews(response.body().getData());
                 } else {
                     Toast.makeText(AdminTicketDetailActivity.this,
                             getString(R.string.error_loading_tickets), Toast.LENGTH_SHORT).show();
@@ -97,7 +98,7 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onFailure(Call<Ticket> call, Throwable t) {
+            public void onFailure(Call<ApiResponse<Ticket>> call, Throwable t) {
                 Toast.makeText(AdminTicketDetailActivity.this,
                         getString(R.string.error_network), Toast.LENGTH_SHORT).show();
                 finish();
@@ -131,12 +132,13 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
     private void updateStatus() {
         String selectedStatus = STATUS_OPTIONS[spinnerCategory.getSelectedItemPosition()];
         ticketService.updateTicketStatus(ticketId, new StatusUpdateRequest(selectedStatus))
-                .enqueue(new Callback<Ticket>() {
+                .enqueue(new Callback<ApiResponse<Ticket>>() {
                     @Override
-                    public void onResponse(Call<Ticket> call, Response<Ticket> response) {
-                        if (response.isSuccessful() && response.body() != null) {
-                            tvStatus.setText(response.body().getStatus());
-                            tvStatus.setBackground(getStatusDrawable(response.body().getStatus()));
+                    public void onResponse(Call<ApiResponse<Ticket>> call, Response<ApiResponse<Ticket>> response) {
+                        if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                            Ticket updatedTicket = response.body().getData();
+                            tvStatus.setText(updatedTicket.getStatus());
+                            tvStatus.setBackground(getStatusDrawable(updatedTicket.getStatus()));
                             Snackbar.make(btnUpdateStatus,
                                     getString(R.string.status_updated), Snackbar.LENGTH_SHORT).show();
                         } else if (response.code() == 400) {
@@ -152,7 +154,7 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
                     }
 
                     @Override
-                    public void onFailure(Call<Ticket> call, Throwable t) {
+                    public void onFailure(Call<ApiResponse<Ticket>> call, Throwable t) {
                         Snackbar.make(btnUpdateStatus,
                                 getString(R.string.error_network), Snackbar.LENGTH_SHORT).show();
                     }

--- a/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketListActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketListActivity.java
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.ucms_android.R;
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.Ticket;
 import com.example.ucms_android.network.ApiClient;
 import com.example.ucms_android.network.TicketService;
@@ -83,11 +84,11 @@ public class AdminTicketListActivity extends AppCompatActivity {
     }
 
     private void loadTickets() {
-        ticketService.getTickets().enqueue(new Callback<List<Ticket>>() {
+        ticketService.getTickets(null).enqueue(new Callback<ApiResponse<List<Ticket>>>() {
             @Override
-            public void onResponse(Call<List<Ticket>> call, Response<List<Ticket>> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    allTickets = response.body();
+            public void onResponse(Call<ApiResponse<List<Ticket>>> call, Response<ApiResponse<List<Ticket>>> response) {
+                if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                    allTickets = response.body().getData();
                     applyFilter();
                 } else {
                     Toast.makeText(AdminTicketListActivity.this,
@@ -96,7 +97,7 @@ public class AdminTicketListActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onFailure(Call<List<Ticket>> call, Throwable t) {
+            public void onFailure(Call<ApiResponse<List<Ticket>>> call, Throwable t) {
                 Toast.makeText(AdminTicketListActivity.this,
                         getString(R.string.error_network), Toast.LENGTH_SHORT).show();
             }

--- a/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketListFragment.java
+++ b/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketListFragment.java
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.ucms_android.R;
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.Ticket;
 import com.example.ucms_android.network.ApiClient;
 import com.example.ucms_android.network.TicketService;
@@ -114,16 +115,16 @@ public class AdminTicketListFragment extends Fragment {
     }
 
     private void loadTickets() {
-        ticketService.getTickets().enqueue(new Callback<List<Ticket>>() {
+        ticketService.getTickets(null).enqueue(new Callback<ApiResponse<List<Ticket>>>() {
             @Override
-            public void onResponse(@NonNull Call<List<Ticket>> call,
-                                   @NonNull Response<List<Ticket>> response) {
+            public void onResponse(@NonNull Call<ApiResponse<List<Ticket>>> call,
+                                   @NonNull Response<ApiResponse<List<Ticket>>> response) {
                 if (!isAdded()) {
                     return;
                 }
                 requireActivity().runOnUiThread(() -> {
-                    if (response.isSuccessful() && response.body() != null) {
-                        allTickets = response.body();
+                    if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                        allTickets = response.body().getData();
                         applyFilter();
                     } else {
                         Toast.makeText(requireContext(),
@@ -134,7 +135,7 @@ public class AdminTicketListFragment extends Fragment {
             }
 
             @Override
-            public void onFailure(@NonNull Call<List<Ticket>> call, @NonNull Throwable t) {
+            public void onFailure(@NonNull Call<ApiResponse<List<Ticket>>> call, @NonNull Throwable t) {
                 if (!isAdded()) {
                     return;
                 }

--- a/app/src/main/java/com/example/ucms_android/ui/student/SubmitTicketActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/student/SubmitTicketActivity.java
@@ -14,6 +14,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.ucms_android.R;
 import com.example.ucms_android.auth.EmailVerificationActivity;
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.Category;
 import com.example.ucms_android.model.Ticket;
 import com.example.ucms_android.model.TicketRequest;
@@ -78,11 +79,11 @@ public class SubmitTicketActivity extends AppCompatActivity {
     }
 
     private void loadCategories() {
-        categoryService.getCategories().enqueue(new Callback<List<Category>>() {
+        categoryService.getCategories().enqueue(new Callback<ApiResponse<List<Category>>>() {
             @Override
-            public void onResponse(Call<List<Category>> call, Response<List<Category>> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    categories = response.body();
+            public void onResponse(Call<ApiResponse<List<Category>>> call, Response<ApiResponse<List<Category>>> response) {
+                if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                    categories = response.body().getData();
                     ArrayAdapter<Category> adapter = new ArrayAdapter<>(
                             SubmitTicketActivity.this,
                             android.R.layout.simple_spinner_item,
@@ -96,7 +97,7 @@ public class SubmitTicketActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onFailure(Call<List<Category>> call, Throwable t) {
+            public void onFailure(Call<ApiResponse<List<Category>>> call, Throwable t) {
                 Toast.makeText(SubmitTicketActivity.this,
                         getString(R.string.error_network), Toast.LENGTH_SHORT).show();
             }
@@ -125,10 +126,10 @@ public class SubmitTicketActivity extends AppCompatActivity {
         String category = categories.isEmpty() ? "" : categories.get(spinnerCategory.getSelectedItemPosition()).getName();
         TicketRequest request = new TicketRequest(title, description, category);
 
-        ticketService.createTicket(request).enqueue(new Callback<Ticket>() {
+        ticketService.createTicket(request).enqueue(new Callback<ApiResponse<Ticket>>() {
             @Override
-            public void onResponse(Call<Ticket> call, Response<Ticket> response) {
-                if (response.isSuccessful()) {
+            public void onResponse(Call<ApiResponse<Ticket>> call, Response<ApiResponse<Ticket>> response) {
+                if (response.isSuccessful() && response.body() != null && response.body().isSuccess()) {
                     Toast.makeText(SubmitTicketActivity.this,
                             getString(R.string.ticket_submitted), Toast.LENGTH_SHORT).show();
                     finish();
@@ -141,7 +142,7 @@ public class SubmitTicketActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onFailure(Call<Ticket> call, Throwable t) {
+            public void onFailure(Call<ApiResponse<Ticket>> call, Throwable t) {
                 Snackbar.make(btnSubmit,
                         getString(R.string.error_network), Snackbar.LENGTH_SHORT).show();
             }

--- a/app/src/main/java/com/example/ucms_android/ui/student/TicketDetailActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/student/TicketDetailActivity.java
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.ucms_android.R;
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.Ticket;
 import com.example.ucms_android.model.TicketResponse;
 import com.example.ucms_android.network.ApiClient;
@@ -72,11 +73,11 @@ public class TicketDetailActivity extends AppCompatActivity {
     }
 
     private void loadTicket() {
-        ticketService.getTicketById(ticketId).enqueue(new Callback<Ticket>() {
+        ticketService.getTicketById(ticketId).enqueue(new Callback<ApiResponse<Ticket>>() {
             @Override
-            public void onResponse(Call<Ticket> call, Response<Ticket> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    populateViews(response.body());
+            public void onResponse(Call<ApiResponse<Ticket>> call, Response<ApiResponse<Ticket>> response) {
+                if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                    populateViews(response.body().getData());
                 } else {
                     Toast.makeText(TicketDetailActivity.this,
                             getString(R.string.error_loading_tickets), Toast.LENGTH_SHORT).show();
@@ -85,7 +86,7 @@ public class TicketDetailActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onFailure(Call<Ticket> call, Throwable t) {
+            public void onFailure(Call<ApiResponse<Ticket>> call, Throwable t) {
                 Toast.makeText(TicketDetailActivity.this,
                         getString(R.string.error_network), Toast.LENGTH_SHORT).show();
                 finish();
@@ -113,16 +114,16 @@ public class TicketDetailActivity extends AppCompatActivity {
     }
 
     private void loadResponses() {
-        ticketService.getTicketResponses(ticketId).enqueue(new Callback<List<TicketResponse>>() {
+        ticketService.getTicketResponses(ticketId).enqueue(new Callback<ApiResponse<List<TicketResponse>>>() {
             @Override
-            public void onResponse(Call<List<TicketResponse>> call, Response<List<TicketResponse>> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    responseAdapter.updateData(response.body());
+            public void onResponse(Call<ApiResponse<List<TicketResponse>>> call, Response<ApiResponse<List<TicketResponse>>> response) {
+                if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                    responseAdapter.updateData(response.body().getData());
                 }
             }
 
             @Override
-            public void onFailure(Call<List<TicketResponse>> call, Throwable t) {
+            public void onFailure(Call<ApiResponse<List<TicketResponse>>> call, Throwable t) {
                 // Silently fail — responses are supplementary
             }
         });

--- a/app/src/main/java/com/example/ucms_android/ui/student/TicketListActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/student/TicketListActivity.java
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.ucms_android.R;
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.Ticket;
 import com.example.ucms_android.network.ApiClient;
 import com.example.ucms_android.network.TicketService;
@@ -64,11 +65,11 @@ public class TicketListActivity extends AppCompatActivity {
     }
 
     private void loadTickets() {
-        ticketService.getTickets().enqueue(new Callback<List<Ticket>>() {
+        ticketService.getTickets(null).enqueue(new Callback<ApiResponse<List<Ticket>>>() {
             @Override
-            public void onResponse(Call<List<Ticket>> call, Response<List<Ticket>> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    List<Ticket> tickets = response.body();
+            public void onResponse(Call<ApiResponse<List<Ticket>>> call, Response<ApiResponse<List<Ticket>>> response) {
+                if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                    List<Ticket> tickets = response.body().getData();
                     if (tickets.isEmpty()) {
                         rvTickets.setVisibility(View.GONE);
                         tvEmptyState.setVisibility(View.VISIBLE);
@@ -84,7 +85,7 @@ public class TicketListActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onFailure(Call<List<Ticket>> call, Throwable t) {
+            public void onFailure(Call<ApiResponse<List<Ticket>>> call, Throwable t) {
                 Toast.makeText(TicketListActivity.this,
                         getString(R.string.error_network), Toast.LENGTH_SHORT).show();
             }

--- a/app/src/main/java/com/example/ucms_android/ui/student/TicketListFragment.java
+++ b/app/src/main/java/com/example/ucms_android/ui/student/TicketListFragment.java
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.ucms_android.R;
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.Ticket;
 import com.example.ucms_android.network.ApiClient;
 import com.example.ucms_android.network.TicketService;
@@ -74,16 +75,16 @@ public class TicketListFragment extends Fragment {
     }
 
     private void loadTickets() {
-        ticketService.getTickets().enqueue(new Callback<List<Ticket>>() {
+        ticketService.getTickets(null).enqueue(new Callback<ApiResponse<List<Ticket>>>() {
             @Override
-            public void onResponse(@NonNull Call<List<Ticket>> call,
-                                   @NonNull Response<List<Ticket>> response) {
+            public void onResponse(@NonNull Call<ApiResponse<List<Ticket>>> call,
+                                   @NonNull Response<ApiResponse<List<Ticket>>> response) {
                 if (!isAdded()) {
                     return;
                 }
                 requireActivity().runOnUiThread(() -> {
-                    if (response.isSuccessful() && response.body() != null) {
-                        List<Ticket> tickets = response.body();
+                    if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                        List<Ticket> tickets = response.body().getData();
                         if (tickets.isEmpty()) {
                             rvTickets.setVisibility(View.GONE);
                             tvEmptyState.setVisibility(View.VISIBLE);
@@ -101,7 +102,7 @@ public class TicketListFragment extends Fragment {
             }
 
             @Override
-            public void onFailure(@NonNull Call<List<Ticket>> call, @NonNull Throwable t) {
+            public void onFailure(@NonNull Call<ApiResponse<List<Ticket>>> call, @NonNull Throwable t) {
                 if (!isAdded()) {
                     return;
                 }


### PR DESCRIPTION
## Type of Change
- [x] fix — bug fix

## Labels
<!-- priority: p1-high | type: fix | scope: android -->

## What Changed
Wraps all Retrofit service return types with `ApiResponse<T>` and unwraps `.getData()` in all ticket and category consumers: `CategoryService`, `TicketService`, `SubmitTicketActivity`, `TicketListActivity`, `TicketListFragment`, `TicketDetailActivity`, `AdminDashboardActivity`, `AdminDashboardFragment`, `AdminTicketListActivity`, `AdminTicketListFragment`, `AdminTicketDetailActivity`.

## Why
Backend wraps all responses in `{"success":true,"data":...}`. Android was deserializing directly into the raw type, causing `response.body()` to always be null and screens to show blank/empty.

## How to Test
1. Build and run the app
2. Log in as student — ticket list should populate
3. Open Submit Ticket — category spinner should populate
4. Submit a ticket — should succeed

## Checklist
- [x] Code follows the Google Java Style Guide
- [x] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal API response handling structure across the application to standardize how network requests and responses are processed throughout the Android client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->