### PR TITLE
fix: add 192.168.135.141 to cleartext whitelist for phone hotspot testing

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -3,5 +3,6 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="false">10.0.2.2</domain>
         <domain includeSubdomains="false">192.168.1.9</domain>
+        <domain includeSubdomains="false">192.168.135.141</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Type of Change
- [x] fix — bug fix

## Labels
<!-- priority: p2-medium | type: fix | scope: android -->

## What Changed
Adds `192.168.135.141` to `network_security_config.xml` cleartext whitelist.

## Why
When using phone hotspot for testing, the laptop gets a different IP. Without this, all API calls fail with `CLEARTEXT communication not permitted`.

## How to Test
1. Connect laptop to phone hotspot
2. Run backend on laptop
3. Install and run app — network calls should succeed

## Checklist
- [x] CI passes