### PR TITLE
chore: remove empty stub RegisterActivity from ui/auth package

### DIFF
--- a/app/src/main/java/com/example/ucms_android/ui/auth/RegisterActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/auth/RegisterActivity.java
@@ -1,7 +1,0 @@
-package com.example.ucms_android.ui.auth;
-
-import androidx.appcompat.app.AppCompatActivity;
-
-public class RegisterActivity extends AppCompatActivity {
-    // TODO: implement screen
-}


### PR DESCRIPTION
## Type of Change
- [x] chore — maintenance

## Labels
<!-- priority: p3-low | type: chore | scope: android -->

## What Changed
Removes the empty stub `RegisterActivity.java` from `ui/auth/` package. The real implementation lives at the root package level.

## Why
Dead code cleanup — the stub was never used and caused confusion.

## How to Test
1. Build the app — should compile without errors

## Checklist
- [x] CI passes