### PR TITLE
feat: wire /me endpoint and add profile cache to student screens

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,3 +151,39 @@ Apply labels when creating GitHub issues and PRs. Use one from each relevant gro
 | `backend` | Backend only |
 | `android` | Android only |
 | `infra` | CI/CD, GitHub Actions, secrets |
+
+## Issue Template
+
+Use this format when creating GitHub issues:
+
+```
+### Overview
+<!-- A concise description of what this issue covers and why it's needed. -->
+
+### Blocked on
+<!-- List any issues that must be completed first. Remove this section if not blocked. -->
+
+### Tasks
+<!-- Checklist of concrete implementation steps. One task per line. -->
+- [ ] 
+
+### View IDs
+<!-- List all XML view IDs introduced or used in this issue (Design issues only). -->
+
+### References
+<!-- Link to relevant docs, layouts, or related issues. -->
+- 
+
+### Acceptance Criteria
+<!-- Define what "done" looks like. Each criterion must be independently verifiable. -->
+- 
+```
+
+### Guidelines
+- **Title format:** `[Phase X<letter>-D] Design: <Screen Name>` or `[Phase X<letter>-L] Logic: <Screen Name>`
+- **Design before Logic** — always create and complete the Design issue before starting the Logic issue
+- **One screen per issue** — do not mix unrelated screens
+- **Design tasks** must list all XML layout files, view IDs, and drawable/style references
+- **Logic tasks** must reference view IDs from the Design issue and API endpoints from docs/api-contract.md
+- **Acceptance Criteria** must be testable on a device/emulator — include empty states, error states, and edge cases
+- **Labels** — always apply priority + type + scope

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,9 +59,6 @@
         <activity
             android:name=".ui.admin.AdminTicketDetailActivity"
             android:exported="false" />
-        <activity
-            android:name=".ui.admin.AnalyticsActivity"
-            android:exported="false" />
 
         <!-- Student screens -->
         <activity

--- a/app/src/main/java/com/example/ucms_android/MainActivity.java
+++ b/app/src/main/java/com/example/ucms_android/MainActivity.java
@@ -28,31 +28,40 @@ public class MainActivity extends AppCompatActivity {
         
         setContentView(R.layout.activity_main);
 
-        // FORCED TO ADMIN ROLE FOR UI TESTING
-        String role = ROLE_ADMIN; 
+        String role = sessionManager.getRole();
         isAdmin = ROLE_ADMIN.equalsIgnoreCase(role);
 
         BottomNavigationView bottomNav = findViewById(R.id.bottomNavView);
         
-        // Re-inflate menu specifically for Admin
         bottomNav.getMenu().clear();
-        bottomNav.inflateMenu(R.menu.menu_admin);
+        if (isAdmin) {
+            bottomNav.inflateMenu(R.menu.menu_admin);
 
-        if (savedInstanceState == null) {
-            // Load Admin Dashboard by default
-            loadFragment(new AdminDashboardFragment());
-            bottomNav.setSelectedItemId(R.id.nav_admin_dashboard);
+            if (savedInstanceState == null) {
+                loadFragment(new AdminDashboardFragment());
+                bottomNav.setSelectedItemId(R.id.nav_admin_dashboard);
+            }
+        } else {
+            bottomNav.inflateMenu(R.menu.menu_student);
+
+            if (savedInstanceState == null) {
+                loadFragment(new StudentHomeFragment());
+                bottomNav.setSelectedItemId(R.id.nav_student_home);
+            }
         }
 
         bottomNav.setOnItemSelectedListener(item -> {
             Fragment fragment = null;
             int itemId = item.getItemId();
 
-            // Admin Navigation
             if (itemId == R.id.nav_admin_dashboard) fragment = new AdminDashboardFragment();
             else if (itemId == R.id.nav_admin_tickets) fragment = new AdminTicketListFragment();
             else if (itemId == R.id.nav_admin_analytics) fragment = new AnalyticsFragment();
             else if (itemId == R.id.nav_admin_settings) fragment = new SettingsFragment();
+            else if (itemId == R.id.nav_student_home) fragment = new StudentHomeFragment();
+            else if (itemId == R.id.nav_student_tickets) fragment = new TicketListFragment();
+    else if (itemId == R.id.nav_student_add) fragment = new SubmitTicketFragment();
+            else if (itemId == R.id.nav_student_profile) fragment = new StudentProfileFragment();
             
             if (fragment != null) {
                 loadFragment(fragment);

--- a/app/src/main/java/com/example/ucms_android/model/User.java
+++ b/app/src/main/java/com/example/ucms_android/model/User.java
@@ -1,5 +1,25 @@
 package com.example.ucms_android.model;
 
+import com.google.gson.annotations.SerializedName;
+
 public class User {
-    // TODO: response fields
+    @SerializedName("authUserId") private String authUserId;
+    @SerializedName("studentId") private String studentId;
+    @SerializedName("name") private String name;
+    @SerializedName("email") private String email;
+    @SerializedName("emailVerified") private boolean emailVerified;
+    @SerializedName("course") private String course;
+    @SerializedName("yearLevel") private Integer yearLevel;
+    @SerializedName("role") private String role;
+    @SerializedName("createdAt") private String createdAt;
+
+    public String getAuthUserId() { return authUserId; }
+    public String getStudentId() { return studentId; }
+    public String getName() { return name; }
+    public String getEmail() { return email; }
+    public boolean isEmailVerified() { return emailVerified; }
+    public String getCourse() { return course; }
+    public Integer getYearLevel() { return yearLevel; }
+    public String getRole() { return role; }
+    public String getCreatedAt() { return createdAt; }
 }

--- a/app/src/main/java/com/example/ucms_android/network/UserService.java
+++ b/app/src/main/java/com/example/ucms_android/network/UserService.java
@@ -1,12 +1,22 @@
 package com.example.ucms_android.network;
 
+import com.example.ucms_android.model.ApiResponse;
+import com.example.ucms_android.model.User;
+
 import java.util.Map;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.GET;
 import retrofit2.http.PUT;
 
 public interface UserService {
+    @GET("api/users/me")
+    Call<ApiResponse<User>> getMe();
+
     @PUT("api/users/me/email")
     Call<Void> updateEmail(@Body Map<String, String> body);
+
+    @PUT("api/users/me")
+    Call<ApiResponse<User>> updateProfile(@Body Map<String, Object> body);
 }

--- a/app/src/main/java/com/example/ucms_android/session/SessionManager.java
+++ b/app/src/main/java/com/example/ucms_android/session/SessionManager.java
@@ -8,6 +8,10 @@ public class SessionManager {
     private static final String KEY_TOKEN = "access_token";
     private static final String KEY_ROLE = "user_role";
     private static final String KEY_LOGGED_IN = "is_logged_in";
+    private static final String KEY_CACHED_NAME = "cached_name";
+    private static final String KEY_CACHED_STUDENT_ID = "cached_student_id";
+    private static final String KEY_CACHED_COURSE = "cached_course";
+    private static final String KEY_CACHED_YEAR_LEVEL = "cached_year_level";
 
     private final SharedPreferences sharedPreferences;
     private final SharedPreferences.Editor editor;
@@ -22,6 +26,30 @@ public class SessionManager {
         editor.putString(KEY_ROLE, role);
         editor.putBoolean(KEY_LOGGED_IN, true);
         editor.apply();
+    }
+
+    public void saveProfileCache(String name, String studentId, String course, Integer yearLevel) {
+        editor.putString(KEY_CACHED_NAME, name != null ? name : "");
+        editor.putString(KEY_CACHED_STUDENT_ID, studentId != null ? studentId : "");
+        editor.putString(KEY_CACHED_COURSE, course != null ? course : "");
+        editor.putString(KEY_CACHED_YEAR_LEVEL, yearLevel != null ? String.valueOf(yearLevel) : "");
+        editor.apply();
+    }
+
+    public String getCachedName() {
+        return sharedPreferences.getString(KEY_CACHED_NAME, "");
+    }
+
+    public String getCachedStudentId() {
+        return sharedPreferences.getString(KEY_CACHED_STUDENT_ID, "");
+    }
+
+    public String getCachedCourse() {
+        return sharedPreferences.getString(KEY_CACHED_COURSE, "");
+    }
+
+    public String getCachedYearLevel() {
+        return sharedPreferences.getString(KEY_CACHED_YEAR_LEVEL, "");
     }
 
     public String getToken() {

--- a/app/src/main/java/com/example/ucms_android/ui/auth/LoginActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/auth/LoginActivity.java
@@ -19,6 +19,7 @@ import com.example.ucms_android.model.LoginRequest;
 import com.example.ucms_android.network.ApiClient;
 import com.example.ucms_android.network.AuthService;
 import com.example.ucms_android.session.SessionManager;
+import com.example.ucms_android.auth.TokenManager;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.gson.Gson;
@@ -93,6 +94,8 @@ public class LoginActivity extends AppCompatActivity {
                         if (authResponse != null && authResponse.getAccessToken() != null) {
                             String role = extractRoleFromJwt(authResponse.getAccessToken());
                             sessionManager.saveSession(authResponse.getAccessToken(), role);
+                            TokenManager.getInstance().saveToken(LoginActivity.this, authResponse.getAccessToken());
+                            TokenManager.getInstance().saveRole(LoginActivity.this, role);
                             startActivity(new Intent(LoginActivity.this, MainActivity.class));
                             finish();
                             return;

--- a/app/src/main/java/com/example/ucms_android/ui/student/StudentHomeFragment.java
+++ b/app/src/main/java/com/example/ucms_android/ui/student/StudentHomeFragment.java
@@ -13,13 +13,24 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.ucms_android.R;
+import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.Ticket;
+import com.example.ucms_android.model.User;
+import com.example.ucms_android.network.ApiClient;
+import com.example.ucms_android.network.UserService;
+import com.example.ucms_android.session.SessionManager;
 import com.example.ucms_android.ui.adapter.RecentTicketAdapter;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
 public class StudentHomeFragment extends Fragment {
+
+    private SessionManager sessionManager;
 
     @Nullable
     @Override
@@ -30,6 +41,8 @@ public class StudentHomeFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        sessionManager = new SessionManager(requireContext());
         
         // Setup Submit button listener
         view.findViewById(R.id.btnSubmitNewConcern).setOnClickListener(v -> {
@@ -44,6 +57,36 @@ public class StudentHomeFragment extends Fragment {
         // Setup View All listener
         view.findViewById(R.id.tvViewAll).setOnClickListener(v -> {
             // Navigate to NotificationsActivity
+        });
+
+        String cachedName = sessionManager.getCachedName();
+        if (!cachedName.isEmpty()) {
+            android.widget.TextView tvName = view.findViewById(R.id.tvUserName);
+            if (tvName != null) tvName.setText(cachedName);
+        }
+
+        UserService userService = ApiClient.getInstance(requireContext()).create(UserService.class);
+        userService.getMe().enqueue(new Callback<ApiResponse<User>>() {
+            @Override
+            public void onResponse(@NonNull Call<ApiResponse<User>> call, @NonNull Response<ApiResponse<User>> response) {
+                if (!response.isSuccessful() || response.body() == null || response.body().getData() == null) {
+                    return;
+                }
+                User user = response.body().getData();
+                String name = user.getName();
+                if (name != null && isAdded() && getActivity() != null) {
+                    String finalName = name;
+                    getActivity().runOnUiThread(() -> {
+                        android.widget.TextView tvName = view.findViewById(R.id.tvUserName);
+                        if (tvName != null) tvName.setText(finalName);
+                    });
+                    sessionManager.saveProfileCache(user.getName(), user.getStudentId(), user.getCourse(), user.getYearLevel());
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<ApiResponse<User>> call, @NonNull Throwable t) {
+            }
         });
 
         // Setup RecyclerView with dummy data

--- a/app/src/main/java/com/example/ucms_android/ui/student/StudentProfileFragment.java
+++ b/app/src/main/java/com/example/ucms_android/ui/student/StudentProfileFragment.java
@@ -6,7 +6,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -14,15 +13,26 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import com.example.ucms_android.R;
+import com.example.ucms_android.model.ApiResponse;
+import com.example.ucms_android.model.User;
+import com.example.ucms_android.network.ApiClient;
+import com.example.ucms_android.network.UserService;
 import com.example.ucms_android.session.SessionManager;
 import com.example.ucms_android.ui.auth.LoginActivity;
 import com.google.android.material.button.MaterialButton;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 public class StudentProfileFragment extends Fragment {
 
     private EditText etFullName, etCourse, etYearLevel;
     private MaterialButton btnLogout, btnSaveChanges, btnChangePassword;
     private SessionManager sessionManager;
+    private UserService userService;
 
     @Nullable
     @Override
@@ -43,15 +53,86 @@ public class StudentProfileFragment extends Fragment {
         btnSaveChanges = view.findViewById(R.id.btnSaveChanges);
         btnChangePassword = view.findViewById(R.id.btnChangePassword);
 
-        // Pre-fill with dummy data (In a real app, these would come from SessionManager/User model)
-        etFullName.setText("Rain Louie Robles");
-        etCourse.setText("BS in Computer Science");
-        etYearLevel.setText("3rd Year");
+        String cachedName = sessionManager.getCachedName();
+        String cachedStudentId = sessionManager.getCachedStudentId();
+        String cachedCourse = sessionManager.getCachedCourse();
+        String cachedYearLevel = sessionManager.getCachedYearLevel();
+
+        if (!cachedName.isEmpty()) {
+            etFullName.setText(cachedName);
+            ((android.widget.TextView) view.findViewById(R.id.tvStudentNameHeader)).setText(cachedName);
+        }
+        if (!cachedStudentId.isEmpty()) {
+            ((android.widget.TextView) view.findViewById(R.id.tvStudentNumber)).setText(cachedStudentId);
+        }
+        if (!cachedCourse.isEmpty()) etCourse.setText(cachedCourse);
+        if (!cachedYearLevel.isEmpty()) etYearLevel.setText(cachedYearLevel);
+
+        userService = ApiClient.getInstance(requireContext()).create(UserService.class);
+
+        userService.getMe().enqueue(new Callback<ApiResponse<User>>() {
+            @Override
+            public void onResponse(@NonNull Call<ApiResponse<User>> call, @NonNull Response<ApiResponse<User>> response) {
+                if (!response.isSuccessful() || response.body() == null || response.body().getData() == null) {
+                    return;
+                }
+
+                User user = response.body().getData();
+                if (isAdded() && getActivity() != null) {
+                    getActivity().runOnUiThread(() -> {
+                        etFullName.setText(user.getName());
+                        ((android.widget.TextView) view.findViewById(R.id.tvStudentNameHeader)).setText(user.getName());
+                        ((android.widget.TextView) view.findViewById(R.id.tvStudentNumber)).setText(user.getStudentId());
+                        etCourse.setText(user.getCourse() != null ? user.getCourse() : "");
+                        Integer yearLevel = user.getYearLevel();
+                        etYearLevel.setText(yearLevel != null ? String.valueOf(yearLevel) : "");
+                    });
+                    sessionManager.saveProfileCache(user.getName(), user.getStudentId(), user.getCourse(), user.getYearLevel());
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<ApiResponse<User>> call, @NonNull Throwable t) {
+            }
+        });
 
         btnLogout.setOnClickListener(v -> logout());
         
         btnSaveChanges.setOnClickListener(v -> {
-            Toast.makeText(requireContext(), "Profile changes saved (Simulated)", Toast.LENGTH_SHORT).show();
+            Map<String, Object> body = new HashMap<>();
+            body.put("name", etFullName.getText().toString().trim());
+            body.put("course", etCourse.getText().toString().trim());
+
+            String yearLevelText = etYearLevel.getText().toString().trim();
+            if (!yearLevelText.isEmpty()) {
+                try {
+                    body.put("yearLevel", Integer.parseInt(yearLevelText));
+                } catch (NumberFormatException ignored) {
+                }
+            }
+
+            userService.updateProfile(body).enqueue(new Callback<ApiResponse<User>>() {
+                @Override
+                public void onResponse(@NonNull Call<ApiResponse<User>> call, @NonNull Response<ApiResponse<User>> response) {
+                    if (isAdded() && getActivity() != null) {
+                        getActivity().runOnUiThread(() -> {
+                            if (response.isSuccessful()) {
+                                Toast.makeText(requireContext(), "Profile updated", Toast.LENGTH_SHORT).show();
+                            } else {
+                                Toast.makeText(requireContext(), "Failed to update profile", Toast.LENGTH_SHORT).show();
+                            }
+                        });
+                    }
+                }
+
+                @Override
+                public void onFailure(@NonNull Call<ApiResponse<User>> call, @NonNull Throwable t) {
+                    if (isAdded() && getActivity() != null) {
+                        getActivity().runOnUiThread(() ->
+                                Toast.makeText(requireContext(), "Failed to update profile", Toast.LENGTH_SHORT).show());
+                    }
+                }
+            });
         });
 
         btnChangePassword.setOnClickListener(v -> {

--- a/app/src/main/res/layout/fragment_student_home.xml
+++ b/app/src/main/res/layout/fragment_student_home.xml
@@ -30,7 +30,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/screen_padding"
             android:layout_marginEnd="@dimen/spacing_medium"
-            android:text="Robles, Rain Louie"
+            android:text=""
             android:textColor="@color/black"
             android:textSize="26sp"
             android:textStyle="bold"

--- a/app/src/main/res/layout/fragment_student_profile.xml
+++ b/app/src/main/res/layout/fragment_student_profile.xml
@@ -53,7 +53,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="Rain Louie Robles"
+            android:text=""
             android:textColor="@color/colorTextPrimary"
             android:textSize="24sp"
             app:layout_constraintEnd_toEndOf="parent"
@@ -152,7 +152,7 @@
                     android:layout_height="match_parent"
                     android:gravity="center_vertical"
                     android:paddingHorizontal="16dp"
-                    android:text="20230646-S"
+                    android:text=""
                     android:textColor="#BDBDBD" />
 
                 <ImageView


### PR DESCRIPTION
## Type of Change
- [x] feat — new feature
- [x] fix — bug fix

## What Changed
- Wired `GET /api/users/me` to StudentHomeFragment and StudentProfileFragment
- Added profile cache in SessionManager (name, studentId, course, yearLevel)
- Fixed token storage mismatch — LoginActivity now saves to TokenManager so AuthInterceptor attaches Bearer token correctly
- Fixed MainActivity hardcoded ADMIN role — now reads role from SessionManager for proper routing
- Cleared hardcoded placeholder text from fragment_student_home.xml and fragment_student_profile.xml
## Why
Student home and profile screens were showing hardcoded dummy data instead of real user data. The /me endpoint existed on the backend but the Android client had two bugs preventing it from working: (1) token was saved to SessionManager but AuthInterceptor read from TokenManager, causing all authenticated requests to return 403, and (2) MainActivity forced ADMIN role regardless of actual login.
## How to Test
1. Register a new student account
2. Login — home screen should show real student name
3. Navigate to Profile — name, student ID, course, year level should match DB
4. Switch between screens — cached data appears instantly, no flash of hardcoded text
5. Logout and login again — cache clears, repopulates correctly
## Related Issues
Closes #27 (partial — GET /api/users/me wired on Android)
## Screenshots
<!-- Add before/after screenshots of home and profile screens -->
## Checklist
- [x] No hardcoded strings in logic (XML defaults cleared)
- [x] All API calls go through ApiClient
- [x] JWT attached via AuthInterceptor
- [x] App builds and runs on API 24+
- [x] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an issue template and contribution guidelines.

* **New Features**
  * Role-based navigation: interfaces adapt for admins and students.
  * Dynamic profile: user info now loads from the server, can be edited, and is cached locally for faster display.

* **User-facing Changes**
  * Default placeholder names cleared in student screens.
  * Admin Analytics screen entry removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->