### PR TITLE
fix(sync): merge ticket delta into cached list instead of overwriting

### DIFF
--- a/app/src/main/java/com/example/ucms_android/sync/BootstrapCoordinator.java
+++ b/app/src/main/java/com/example/ucms_android/sync/BootstrapCoordinator.java
@@ -14,11 +14,15 @@ import com.example.ucms_android.network.ApiClient;
 import com.example.ucms_android.network.SyncService;
 import com.example.ucms_android.session.SessionManager;
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
+import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -168,8 +172,14 @@ public class BootstrapCoordinator {
                     return;
                 }
 
-                List<Ticket> tickets = response.body().getData().getItems();
+                List<Ticket> delta = response.body().getData().getItems();
                 String role = sessionManager.getRole();
+                boolean isFullSync = since == null;
+
+                String existingJson = ROLE_ADMIN.equalsIgnoreCase(role)
+                        ? sessionManager.getAdminAllTicketsJson()
+                        : sessionManager.getStudentAllTicketsJson();
+                List<Ticket> tickets = isFullSync ? delta : mergeTickets(existingJson, delta);
 
                 if (ROLE_ADMIN.equalsIgnoreCase(role)) {
                     cacheAdminTicketData(tickets);
@@ -228,6 +238,32 @@ public class BootstrapCoordinator {
                 callback.onFailure("Failed to sync notifications.");
             }
         });
+    }
+
+    /**
+     * Merge an incremental ticket delta into the existing cached list by id.
+     * Incoming items overwrite existing entries with the same id; new items are appended.
+     * Order is preserved (existing first, new ones at the end) so downstream sorting still applies.
+     */
+    private List<Ticket> mergeTickets(String existingJson, List<Ticket> delta) {
+        Map<Long, Ticket> merged = new LinkedHashMap<>();
+        if (existingJson != null) {
+            try {
+                Type type = new TypeToken<List<Ticket>>() {}.getType();
+                List<Ticket> existing = gson.fromJson(existingJson, type);
+                if (existing != null) {
+                    for (Ticket t : existing) {
+                        if (t != null && t.getId() != null) merged.put(t.getId(), t);
+                    }
+                }
+            } catch (Exception ignored) { }
+        }
+        if (delta != null) {
+            for (Ticket t : delta) {
+                if (t != null && t.getId() != null) merged.put(t.getId(), t);
+            }
+        }
+        return new ArrayList<>(merged.values());
     }
 
     private String getSinceParam(String domain) {


### PR DESCRIPTION
BootstrapCoordinator.fetchTickets() uses incremental sync via a `since`                                                                                                               cursor, but cacheAdminTicketData/cacheStudentTicketData treated the
 returned delta as the full dataset. After an admin resolved a ticket,                                                                                                                 
 the delta `[resolvedTicket]` overwrote adminAllTicketsJson, recomputed
  stats from one item, and wrote an empty pending list to
  adminRecentTicketsJson — causing the admin overview to flash
  "No recent concerns found" until the tab was switched and a full
  fetch ran.

  Merge the delta into the existing cached list by id (LinkedHashMap)
  before recomputing stats and recent concerns. Full syncs (since == null)
  still trust the server payload as authoritative.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ticket synchronization to properly handle both full and incremental sync operations, ensuring ticket data is accurately merged and maintained consistently across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->