### PR TITLE
fix(admin): make ticket attachment image tappable to open viewer

### DIFF
--- a/app/src/main/java/com/example/ucms_android/ui/ImageViewerActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/ImageViewerActivity.java
@@ -18,6 +18,7 @@ import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
+import com.bumptech.glide.signature.ObjectKey;
 import com.example.ucms_android.R;
 import com.example.ucms_android.model.ApiResponse;
 import com.example.ucms_android.model.AttachmentResponse;
@@ -60,12 +61,17 @@ public class ImageViewerActivity extends AppCompatActivity {
                         && response.body().getData() != null
                         && !response.body().getData().isEmpty()) {
 
-                    String freshUrl = response.body().getData().get(0).getSignedUrl();
+                    AttachmentResponse att = response.body().getData().get(0);
+                    String freshUrl = att.getSignedUrl();
+                    ObjectKey stableKey = att.getId() != null
+                            ? new ObjectKey("attachment-" + att.getId())
+                            : new ObjectKey("ticket-attachment-" + ticketId);
                     progressBar.setVisibility(View.VISIBLE);
 
                     Glide.with(ImageViewerActivity.this)
                             .load(freshUrl)
-                            .diskCacheStrategy(DiskCacheStrategy.NONE)
+                            .signature(stableKey)
+                            .diskCacheStrategy(DiskCacheStrategy.AUTOMATIC)
                             .transition(DrawableTransitionOptions.withCrossFade())
                             .listener(new RequestListener<Drawable>() {
                                 @Override

--- a/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketDetailActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketDetailActivity.java
@@ -289,7 +289,25 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
                     String mime = attachment.getMimeType();
                     if (mime != null && mime.startsWith("image/")) {
                         ivAttachmentImage.setVisibility(View.VISIBLE);
-                        Glide.with(AdminTicketDetailActivity.this).load(attachment.getSignedUrl()).into(ivAttachmentImage);
+                        com.bumptech.glide.signature.ObjectKey stableKey = attachment.getId() != null
+                                ? new com.bumptech.glide.signature.ObjectKey("attachment-" + attachment.getId())
+                                : new com.bumptech.glide.signature.ObjectKey("ticket-attachment-" + ticketId);
+                        Glide.with(AdminTicketDetailActivity.this)
+                                .load(attachment.getSignedUrl())
+                                .signature(stableKey)
+                                .diskCacheStrategy(com.bumptech.glide.load.engine.DiskCacheStrategy.AUTOMATIC)
+                                .into(ivAttachmentImage);
+                        cvAttachment.setOnClickListener(v -> {
+                            android.content.Intent intent = new android.content.Intent(
+                                    AdminTicketDetailActivity.this,
+                                    com.example.ucms_android.ui.ImageViewerActivity.class);
+                            intent.putExtra(
+                                    com.example.ucms_android.ui.ImageViewerActivity.EXTRA_TICKET_ID,
+                                    ticketId);
+                            startActivity(intent);
+                        });
+                    } else {
+                        cvAttachment.setOnClickListener(null);
                     }
                 }
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image caching strategy for more efficient loading and storage.

* **New Features**
  * Added ability to click on attachment images to open in full-screen viewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->