### PR TITLE
feat: add attachment support for admin ticket responses

### DIFF
--- a/app/src/main/java/com/example/ucms_android/model/AttachmentResponse.java
+++ b/app/src/main/java/com/example/ucms_android/model/AttachmentResponse.java
@@ -22,10 +22,14 @@ public class AttachmentResponse {
     @SerializedName("uploadedAt")
     private String uploadedAt;
 
+    @SerializedName("uploaderRole")
+    private String uploaderRole;
+
     public Long getId() { return id; }
     public String getOriginalFilename() { return originalFilename; }
     public String getMimeType() { return mimeType; }
     public long getSizeBytes() { return sizeBytes; }
     public String getSignedUrl() { return signedUrl; }
     public String getUploadedAt() { return uploadedAt; }
+    public String getUploaderRole() { return uploaderRole; }
 }

--- a/app/src/main/java/com/example/ucms_android/ui/adapter/TimelineAdapter.java
+++ b/app/src/main/java/com/example/ucms_android/ui/adapter/TimelineAdapter.java
@@ -1,5 +1,7 @@
 package com.example.ucms_android.ui.adapter;
 
+import android.content.Context;
+import android.content.Intent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,7 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.ucms_android.R;
-import com.google.android.material.card.MaterialCardView;
+import com.example.ucms_android.ui.ImageViewerActivity;
 
 import java.util.List;
 
@@ -20,11 +22,23 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
         public String adminName;
         public String message;
         public String time;
+        public String attachmentSignedUrl;
+        public String attachmentMimeType;
+        public String attachmentFilename;
 
         public AdminResponse(String adminName, String message, String time) {
             this.adminName = adminName;
             this.message = message;
             this.time = time;
+        }
+
+        public AdminResponse(String adminName, String message, String time,
+                             String attachmentSignedUrl, String attachmentMimeType,
+                             String attachmentFilename) {
+            this(adminName, message, time);
+            this.attachmentSignedUrl = attachmentSignedUrl;
+            this.attachmentMimeType = attachmentMimeType;
+            this.attachmentFilename = attachmentFilename;
         }
     }
 
@@ -43,9 +57,14 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
     }
 
     private List<TimelineEvent> events;
+    private Long ticketId;
 
     public TimelineAdapter(List<TimelineEvent> events) {
         this.events = events;
+    }
+
+    public void setTicketId(Long ticketId) {
+        this.ticketId = ticketId;
     }
 
     public void updateData(List<TimelineEvent> newEvents) {
@@ -85,12 +104,38 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
                 TextView tvName = responseCard.findViewById(R.id.tvAdminName);
                 TextView tvMessage = responseCard.findViewById(R.id.tvAdminMessage);
                 TextView tvTime = responseCard.findViewById(R.id.tvResponseTime);
+                View llAttachFile = responseCard.findViewById(R.id.llAttachmentFile);
+                TextView tvAttachFilename = responseCard.findViewById(R.id.tvAttachFilename);
 
                 tvName.setText(response.adminName != null
                         ? "Admin Response (" + response.adminName + ")"
                         : "Admin Response");
                 tvMessage.setText(response.message);
                 if (tvTime != null) tvTime.setText(response.time);
+
+                if (response.attachmentSignedUrl != null && llAttachFile != null) {
+                    llAttachFile.setVisibility(View.VISIBLE);
+                    if (tvAttachFilename != null) {
+                        tvAttachFilename.setText(
+                                response.attachmentFilename != null
+                                        ? response.attachmentFilename
+                                        : "Attachment");
+                    }
+                    boolean isImage = response.attachmentMimeType != null
+                            && response.attachmentMimeType.startsWith("image/");
+                    if (isImage && ticketId != null) {
+                        llAttachFile.setOnClickListener(v -> {
+                            Context ctx = v.getContext();
+                            Intent intent = new Intent(ctx, ImageViewerActivity.class);
+                            intent.putExtra(ImageViewerActivity.EXTRA_TICKET_ID, ticketId);
+                            ctx.startActivity(intent);
+                        });
+                    } else {
+                        llAttachFile.setOnClickListener(null);
+                    }
+                } else if (llAttachFile != null) {
+                    llAttachFile.setVisibility(View.GONE);
+                }
 
                 holder.llResponses.addView(responseCard);
             }

--- a/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketDetailActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/admin/AdminTicketDetailActivity.java
@@ -1,5 +1,8 @@
 package com.example.ucms_android.ui.admin;
 
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ArrayAdapter;
@@ -11,6 +14,8 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 
 import com.google.android.material.textfield.MaterialAutoCompleteTextView;
 import com.google.android.material.textfield.TextInputLayout;
@@ -50,6 +55,12 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.RequestBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -57,12 +68,13 @@ import retrofit2.Response;
 public class AdminTicketDetailActivity extends AppCompatActivity {
 
     private TextView tvTicketId, tvCategory, tvUrgencyReason, tvSelectedCategory;
-    private TextView tvTitle, tvDescription, tvAttachmentName;
+    private TextView tvTitle, tvDescription;
     private TextView tvAssignedAdminLabel, tvAssignedAdmin;
     private TextInputLayout tilAdminSelect;
     private MaterialAutoCompleteTextView dropAdminSelect;
     private MaterialButton btnAssignToMe;
     private View btnBack, cvAttachment, cvAiScoring;
+    private LinearLayout llStudentAttachments;
     private MaterialButton btnUpdateStatus;
     private ImageButton btnSendComment;
     private ProgressBar pbSendComment;
@@ -70,7 +82,6 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
     private View btnOverrideUrgency;
     private EditText etResponse, etUrgencyOverrideReason;
     private AutoCompleteTextView dropUrgencyLevel;
-    private ImageView ivAttachmentImage;
     private View loadingOverlay;
     private LinearLayout layoutError;
     private NestedScrollView scrollContent;
@@ -87,6 +98,23 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
     private Ticket currentTicket;
     private List<TicketResponse> currentResponses = new ArrayList<>();
     private List<User> loadedAdmins = new ArrayList<>();
+    private List<AttachmentResponse> currentAttachments = new ArrayList<>();
+    private Uri selectedCommentFileUri;
+    private View cvCommentAttachment;
+    private TextView tvCommentAttachmentHint, tvCommentAttachmentName;
+
+    private final ActivityResultLauncher<String[]> commentFilePickerLauncher =
+            registerForActivityResult(new ActivityResultContracts.OpenDocument(), uri -> {
+                if (uri != null) {
+                    selectedCommentFileUri = uri;
+                    getContentResolver().takePersistableUriPermission(
+                            uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                    String segment = uri.getLastPathSegment();
+                    tvCommentAttachmentName.setText(segment != null ? segment : "file");
+                    tvCommentAttachmentName.setVisibility(View.VISIBLE);
+                    tvCommentAttachmentHint.setVisibility(View.GONE);
+                }
+            });
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -107,6 +135,9 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
 
         btnBack.setOnClickListener(v -> finish());
         btnSendComment.setOnClickListener(v -> appendComment());
+        cvCommentAttachment.setOnClickListener(v ->
+                commentFilePickerLauncher.launch(
+                        new String[]{"image/jpeg", "image/png", "application/pdf"}));
         btnAssignToMe.setOnClickListener(v -> assignAdmin());
         fetchAdmins();
 
@@ -127,6 +158,7 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
         setupUrgencyOverrideDropdown();
 
         timelineAdapter = new TimelineAdapter(new ArrayList<>());
+        timelineAdapter.setTicketId(ticketId);
         rvTimeline.setLayoutManager(new LinearLayoutManager(this));
         rvTimeline.setAdapter(timelineAdapter);
         
@@ -140,14 +172,13 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
         tvCategory = findViewById(R.id.tvCategory);
         tvTitle = findViewById(R.id.tvTitle);
         tvDescription = findViewById(R.id.tvDescription);
-        tvAttachmentName = findViewById(R.id.tvAttachmentName);
-        
+
         cvAiScoring = findViewById(R.id.cvAiScoring);
         tvUrgencyReason = findViewById(R.id.tvUrgencyReason);
-        
+
         btnBack = findViewById(R.id.btnBack);
         cvAttachment = findViewById(R.id.cvAttachment);
-        ivAttachmentImage = findViewById(R.id.ivAttachmentImage);
+        llStudentAttachments = findViewById(R.id.llStudentAttachments);
         btnUpdateStatus = findViewById(R.id.btnUpdateStatus);
         
         tvSelectedCategory = findViewById(R.id.tvSelectedCategory);
@@ -173,6 +204,10 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
         tilAdminSelect = findViewById(R.id.tilAdminSelect);
         dropAdminSelect = findViewById(R.id.dropAdminSelect);
         btnAssignToMe = findViewById(R.id.btnAssignToMe);
+
+        cvCommentAttachment = findViewById(R.id.cvCommentAttachment);
+        tvCommentAttachmentHint = findViewById(R.id.tvCommentAttachmentHint);
+        tvCommentAttachmentName = findViewById(R.id.tvCommentAttachmentName);
     }
 
     private void showTimelineShimmer() {
@@ -226,14 +261,43 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
                 android.graphics.Color.parseColor("#9E9E9E")
         ));
 
+        // Match each attachment to the response posted within 2 minutes before it
+        java.util.Map<Long, AttachmentResponse> responseIdToAttachment = new java.util.HashMap<>();
+        java.util.Set<Long> usedAttachmentIds = new java.util.HashSet<>();
+        for (TicketResponse r : sortedResponses) {
+            long rEpoch = parseIso(r.getCreatedAt());
+            if (rEpoch < 0 || r.getId() == null) continue;
+            AttachmentResponse best = null;
+            long bestDiff = Long.MAX_VALUE;
+            for (AttachmentResponse a : currentAttachments) {
+                if (!"ADMIN".equals(a.getUploaderRole())) continue;
+                if (a.getId() != null && usedAttachmentIds.contains(a.getId())) continue;
+                long aEpoch = parseIso(a.getUploadedAt());
+                if (aEpoch < 0) continue;
+                long diff = aEpoch - rEpoch;
+                if (diff >= 0 && diff <= 120 && diff < bestDiff) {
+                    best = a;
+                    bestDiff = diff;
+                }
+            }
+            if (best != null) {
+                responseIdToAttachment.put(r.getId(), best);
+                if (best.getId() != null) usedAttachmentIds.add(best.getId());
+            }
+        }
+
         java.util.Map<String, List<TimelineAdapter.AdminResponse>> statusResponses = new java.util.HashMap<>();
         for (TicketResponse r : sortedResponses) {
             String s = r.getTicketStatus() != null ? r.getTicketStatus().toUpperCase() : "PENDING";
             if (!statusResponses.containsKey(s)) {
                 statusResponses.put(s, new ArrayList<>());
             }
+            AttachmentResponse att = r.getId() != null ? responseIdToAttachment.get(r.getId()) : null;
             statusResponses.get(s).add(new TimelineAdapter.AdminResponse(
-                    r.getAdminName(), r.getMessage(), DateFormatter.formatDate(r.getCreatedAt())));
+                    r.getAdminName(), r.getMessage(), DateFormatter.formatDate(r.getCreatedAt()),
+                    att != null ? att.getSignedUrl() : null,
+                    att != null ? att.getMimeType() : null,
+                    att != null ? att.getOriginalFilename() : null));
         }
 
         List<TimelineAdapter.AdminResponse> pendingRes = statusResponses.get("PENDING");
@@ -431,32 +495,35 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
                                    @NonNull Response<ApiResponse<List<AttachmentResponse>>> response) {
                 shimmerAttachment.stopShimmer();
                 shimmerAttachment.setVisibility(View.GONE);
-                if (!isFinishing() && response.isSuccessful() && response.body() != null && response.body().getData() != null && !response.body().getData().isEmpty()) {
-                    AttachmentResponse attachment = response.body().getData().get(0);
-                    cvAttachment.setVisibility(View.VISIBLE);
-                    tvAttachmentName.setText(attachment.getOriginalFilename());
-                    String mime = attachment.getMimeType();
-                    if (mime != null && mime.startsWith("image/")) {
-                        ivAttachmentImage.setVisibility(View.VISIBLE);
-                        com.bumptech.glide.signature.ObjectKey stableKey = attachment.getId() != null
-                                ? new com.bumptech.glide.signature.ObjectKey("attachment-" + attachment.getId())
-                                : new com.bumptech.glide.signature.ObjectKey("ticket-attachment-" + ticketId);
-                        Glide.with(AdminTicketDetailActivity.this)
-                                .load(attachment.getSignedUrl())
-                                .signature(stableKey)
-                                .diskCacheStrategy(com.bumptech.glide.load.engine.DiskCacheStrategy.AUTOMATIC)
-                                .into(ivAttachmentImage);
-                        cvAttachment.setOnClickListener(v -> {
-                            android.content.Intent intent = new android.content.Intent(
-                                    AdminTicketDetailActivity.this,
-                                    com.example.ucms_android.ui.ImageViewerActivity.class);
-                            intent.putExtra(
-                                    com.example.ucms_android.ui.ImageViewerActivity.EXTRA_TICKET_ID,
-                                    ticketId);
-                            startActivity(intent);
-                        });
-                    } else {
-                        cvAttachment.setOnClickListener(null);
+                if (!isFinishing() && response.isSuccessful() && response.body() != null && response.body().getData() != null) {
+                    currentAttachments = response.body().getData();
+                    buildTimeline();
+
+                    // Show only student-uploaded attachments in the ticket card
+                    List<AttachmentResponse> studentAttachments = new ArrayList<>();
+                    for (AttachmentResponse a : currentAttachments) {
+                        if ("STUDENT".equals(a.getUploaderRole())) studentAttachments.add(a);
+                    }
+                    if (!studentAttachments.isEmpty()) {
+                        llStudentAttachments.removeAllViews();
+                        for (AttachmentResponse a : studentAttachments) {
+                            android.view.View row = android.view.LayoutInflater.from(AdminTicketDetailActivity.this)
+                                    .inflate(R.layout.item_student_attachment_row, llStudentAttachments, false);
+                            ((TextView) row.findViewById(R.id.tvRowFilename)).setText(a.getOriginalFilename());
+                            row.setOnClickListener(v -> {
+                                if (a.getMimeType() != null && a.getMimeType().startsWith("image/")) {
+                                    android.content.Intent intent = new android.content.Intent(
+                                            AdminTicketDetailActivity.this,
+                                            com.example.ucms_android.ui.ImageViewerActivity.class);
+                                    intent.putExtra(
+                                            com.example.ucms_android.ui.ImageViewerActivity.EXTRA_TICKET_ID,
+                                            ticketId);
+                                    startActivity(intent);
+                                }
+                            });
+                            llStudentAttachments.addView(row);
+                        }
+                        cvAttachment.setVisibility(View.VISIBLE);
                     }
                 }
             }
@@ -540,8 +607,12 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
                                            @NonNull Response<ApiResponse<TicketResponse>> response) {
                         if (response.isSuccessful()) {
                             etResponse.setText("");
-                            setSendState("IDLE");
-                            loadResponses();
+                            if (selectedCommentFileUri != null) {
+                                uploadCommentAttachment(ticketId);
+                            } else {
+                                setSendState("IDLE");
+                                loadResponses();
+                            }
                         } else {
                             setSendState("ERROR");
                         }
@@ -551,6 +622,99 @@ public class AdminTicketDetailActivity extends AppCompatActivity {
                         setSendState("ERROR");
                     }
                 });
+    }
+
+    private void uploadCommentAttachment(Long ticketId) {
+        try {
+            ContentResolver resolver = getContentResolver();
+            String mimeType = resolver.getType(selectedCommentFileUri);
+            if (mimeType == null) mimeType = "application/octet-stream";
+
+            InputStream inputStream = resolver.openInputStream(selectedCommentFileUri);
+            if (inputStream == null) {
+                onCommentAttachmentDone();
+                return;
+            }
+
+            byte[] bytes;
+            try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+                byte[] chunk = new byte[4096];
+                int n;
+                while ((n = inputStream.read(chunk)) != -1) buffer.write(chunk, 0, n);
+                bytes = buffer.toByteArray();
+            }
+            inputStream.close();
+
+            String filename = selectedCommentFileUri.getLastPathSegment();
+            if (filename == null) filename = "file";
+
+            RequestBody requestBody = RequestBody.create(bytes, MediaType.parse(mimeType));
+            MultipartBody.Part filePart =
+                    MultipartBody.Part.createFormData("file", filename, requestBody);
+
+            ticketService.uploadAttachment(ticketId, filePart)
+                    .enqueue(new Callback<ApiResponse<AttachmentResponse>>() {
+                        @Override
+                        public void onResponse(@NonNull Call<ApiResponse<AttachmentResponse>> call,
+                                               @NonNull Response<ApiResponse<AttachmentResponse>> response) {
+                            if (!response.isSuccessful()) {
+                                Toast.makeText(AdminTicketDetailActivity.this,
+                                        resolveAttachmentError(response), Toast.LENGTH_LONG).show();
+                            }
+                            onCommentAttachmentDone();
+                        }
+                        @Override
+                        public void onFailure(@NonNull Call<ApiResponse<AttachmentResponse>> call,
+                                              @NonNull Throwable t) {
+                            Toast.makeText(AdminTicketDetailActivity.this,
+                                    "Comment sent but attachment failed to upload.", Toast.LENGTH_LONG).show();
+                            onCommentAttachmentDone();
+                        }
+                    });
+        } catch (Exception e) {
+            onCommentAttachmentDone();
+        }
+    }
+
+    private static long parseIso(String iso) {
+        if (iso == null || iso.isEmpty()) return -1;
+        try {
+            return java.time.LocalDateTime.parse(iso)
+                    .toEpochSecond(java.time.ZoneOffset.UTC);
+        } catch (Exception e1) {
+            try {
+                return java.time.OffsetDateTime.parse(iso).toEpochSecond();
+            } catch (Exception e2) {
+                return -1;
+            }
+        }
+    }
+
+    private String resolveAttachmentError(Response<?> response) {
+        try {
+            String body = response.errorBody().string();
+            ApiResponse<?> err = new Gson().fromJson(body, ApiResponse.class);
+            if (err != null && err.getErrorCode() != null) {
+                switch (err.getErrorCode()) {
+                    case "TICKET_CLOSED":
+                        return "Comment sent. Attachments cannot be added to a closed or resolved ticket.";
+                    case "INVALID_FILE_TYPE":
+                        return "Comment sent. File type not allowed — use JPEG, PNG, or PDF.";
+                    case "FILE_TOO_LARGE":
+                        return "Comment sent. File exceeds the 10 MB limit.";
+                }
+            }
+        } catch (Exception ignored) {}
+        return "Comment sent but attachment failed to upload.";
+    }
+
+    private void onCommentAttachmentDone() {
+        selectedCommentFileUri = null;
+        tvCommentAttachmentName.setVisibility(View.GONE);
+        tvCommentAttachmentHint.setVisibility(View.VISIBLE);
+        setSendState("IDLE");
+        loadResponses();
+        loadAttachments();
     }
 
     private void setSendState(String state) {

--- a/app/src/main/java/com/example/ucms_android/ui/student/TicketDetailActivity.java
+++ b/app/src/main/java/com/example/ucms_android/ui/student/TicketDetailActivity.java
@@ -5,7 +5,7 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
-import android.widget.ScrollView;
+import androidx.core.widget.NestedScrollView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -42,25 +42,25 @@ import retrofit2.Response;
 public class TicketDetailActivity extends AppCompatActivity {
 
     private ImageView btnBack;
-    private TextView tvTicketNumber, tvCategoryName, tvTicketTitle, tvDescription, tvAttachmentName, tvAssignedAdmin;
+    private TextView tvTicketNumber, tvCategoryName, tvTicketTitle, tvDescription, tvAssignedAdmin;
     private View layoutAssignedAdmin;
-    private ImageView ivAttachmentPreview;
     private View cvAttachment;
-    private LinearLayout layoutAttachmentContent;
+    private LinearLayout llStudentAttachments;
     private ShimmerFrameLayout shimmerAttachment;
     private ShimmerFrameLayout shimmerTimeline;
     private RecyclerView rvTimeline;
     private TimelineAdapter timelineAdapter;
     private ProgressBar progressBar;
     private LinearLayout layoutError;
-    private ScrollView scrollContent;
     private com.google.android.material.button.MaterialButton btnCloseTicket;
+    private NestedScrollView scrollContent;
     private TicketService ticketService;
     private Long ticketId;
     private SessionManager sessionManager;
     private Gson gson;
     private Ticket currentTicket;
     private List<TicketResponse> currentResponses = new ArrayList<>();
+    private List<com.example.ucms_android.model.AttachmentResponse> currentAttachments = new ArrayList<>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -84,6 +84,7 @@ public class TicketDetailActivity extends AppCompatActivity {
         });
 
         timelineAdapter = new TimelineAdapter(new ArrayList<>());
+        timelineAdapter.setTicketId(ticketId);
         rvTimeline.setLayoutManager(new LinearLayoutManager(this));
         rvTimeline.setAdapter(timelineAdapter);
 
@@ -98,10 +99,8 @@ public class TicketDetailActivity extends AppCompatActivity {
         tvCategoryName = findViewById(R.id.tvCategoryName);
         tvTicketTitle = findViewById(R.id.tvTicketTitle);
         tvDescription = findViewById(R.id.tvDescription);
-        tvAttachmentName = findViewById(R.id.tvAttachmentName);
-        ivAttachmentPreview = findViewById(R.id.ivAttachmentPreview);
         cvAttachment = findViewById(R.id.cvAttachment);
-        layoutAttachmentContent = findViewById(R.id.layoutAttachmentContent);
+        llStudentAttachments = findViewById(R.id.llStudentAttachments);
         layoutAssignedAdmin = findViewById(R.id.layoutAssignedAdmin);
         tvAssignedAdmin = findViewById(R.id.tvAssignedAdmin);
         shimmerAttachment = findViewById(R.id.shimmerAttachment);
@@ -204,7 +203,8 @@ public class TicketDetailActivity extends AppCompatActivity {
         tvCategoryName.setText(ticket.getCategoryName() != null ? ticket.getCategoryName() : "");
         tvTicketTitle.setText(ticket.getTitle());
         tvDescription.setText(ticket.getDescription());
-        layoutAttachmentContent.setVisibility(View.GONE);
+        llStudentAttachments.removeAllViews();
+        llStudentAttachments.setVisibility(View.GONE);
         String assignedName = ticket.getAssignedAdminName();
         if (assignedName != null && !assignedName.isEmpty()) {
             tvAssignedAdmin.setText(assignedName);
@@ -283,6 +283,31 @@ public class TicketDetailActivity extends AppCompatActivity {
                 android.graphics.Color.parseColor("#9E9E9E")
         ));
 
+        // Match each attachment to the response posted within 2 minutes before it
+        java.util.Map<Long, com.example.ucms_android.model.AttachmentResponse> responseIdToAttachment = new java.util.HashMap<>();
+        java.util.Set<Long> usedAttachmentIds = new java.util.HashSet<>();
+        for (TicketResponse r : sortedResponses) {
+            long rEpoch = parseIso(r.getCreatedAt());
+            if (rEpoch < 0 || r.getId() == null) continue;
+            com.example.ucms_android.model.AttachmentResponse best = null;
+            long bestDiff = Long.MAX_VALUE;
+            for (com.example.ucms_android.model.AttachmentResponse a : currentAttachments) {
+                if (!"ADMIN".equals(a.getUploaderRole())) continue;
+                if (a.getId() != null && usedAttachmentIds.contains(a.getId())) continue;
+                long aEpoch = parseIso(a.getUploadedAt());
+                if (aEpoch < 0) continue;
+                long diff = aEpoch - rEpoch;
+                if (diff >= 0 && diff <= 120 && diff < bestDiff) {
+                    best = a;
+                    bestDiff = diff;
+                }
+            }
+            if (best != null) {
+                responseIdToAttachment.put(r.getId(), best);
+                if (best.getId() != null) usedAttachmentIds.add(best.getId());
+            }
+        }
+
         // Group responses by status to show them in the correct status section
         java.util.Map<String, List<TimelineAdapter.AdminResponse>> statusResponses = new java.util.HashMap<>();
         for (TicketResponse r : sortedResponses) {
@@ -290,8 +315,13 @@ public class TicketDetailActivity extends AppCompatActivity {
             if (!statusResponses.containsKey(s)) {
                 statusResponses.put(s, new ArrayList<>());
             }
+            com.example.ucms_android.model.AttachmentResponse att =
+                    r.getId() != null ? responseIdToAttachment.get(r.getId()) : null;
             statusResponses.get(s).add(new TimelineAdapter.AdminResponse(
-                    r.getAdminName(), r.getMessage(), DateFormatter.formatDate(r.getCreatedAt())));
+                    r.getAdminName(), r.getMessage(), DateFormatter.formatDate(r.getCreatedAt()),
+                    att != null ? att.getSignedUrl() : null,
+                    att != null ? att.getMimeType() : null,
+                    att != null ? att.getOriginalFilename() : null));
         }
 
         // 2. Pending Responses (Initial phase)
@@ -353,11 +383,26 @@ public class TicketDetailActivity extends AppCompatActivity {
         }
     }
 
+    private static long parseIso(String iso) {
+        if (iso == null || iso.isEmpty()) return -1;
+        try {
+            return java.time.LocalDateTime.parse(iso)
+                    .toEpochSecond(java.time.ZoneOffset.UTC);
+        } catch (Exception e1) {
+            try {
+                return java.time.OffsetDateTime.parse(iso).toEpochSecond();
+            } catch (Exception e2) {
+                return -1;
+            }
+        }
+    }
+
     private void loadAttachments() {
         cvAttachment.setVisibility(View.VISIBLE);
         shimmerAttachment.setVisibility(View.VISIBLE);
         shimmerAttachment.startShimmer();
-        layoutAttachmentContent.setVisibility(View.GONE);
+        llStudentAttachments.removeAllViews();
+        llStudentAttachments.setVisibility(View.GONE);
 
         ticketService.getAttachments(ticketId).enqueue(new Callback<ApiResponse<List<AttachmentResponse>>>() {
             @Override
@@ -368,27 +413,40 @@ public class TicketDetailActivity extends AppCompatActivity {
 
                 if (!isFinishing() && response.isSuccessful()
                         && response.body() != null
-                        && response.body().getData() != null
-                        && !response.body().getData().isEmpty()) {
+                        && response.body().getData() != null) {
 
-                    AttachmentResponse attachment = response.body().getData().get(0);
-                    tvAttachmentName.setText(attachment.getOriginalFilename());
-                    layoutAttachmentContent.setVisibility(View.VISIBLE);
+                    currentAttachments = response.body().getData();
+                    buildTimeline();
 
-        ivAttachmentPreview.setVisibility(View.VISIBLE);
-        ivAttachmentPreview.setImageResource(R.drawable.ic_attachment);
-
-                String mime = attachment.getMimeType();
-                if (mime != null && mime.startsWith("image/")) {
-                    cvAttachment.setOnClickListener(v -> {
-                        android.content.Intent intent = new android.content.Intent(TicketDetailActivity.this,
-                                com.example.ucms_android.ui.ImageViewerActivity.class);
-                        intent.putExtra(com.example.ucms_android.ui.ImageViewerActivity.EXTRA_TICKET_ID, ticketId);
-                        startActivity(intent);
-                    });
-                } else {
-                    cvAttachment.setOnClickListener(null);
-                }
+                    // Show only student-uploaded attachments in the ticket card
+                    List<AttachmentResponse> studentAttachments = new ArrayList<>();
+                    for (AttachmentResponse a : currentAttachments) {
+                        if ("STUDENT".equals(a.getUploaderRole())) studentAttachments.add(a);
+                    }
+                    if (!studentAttachments.isEmpty()) {
+                        llStudentAttachments.removeAllViews();
+                        for (AttachmentResponse a : studentAttachments) {
+                            android.view.View row = android.view.LayoutInflater.from(TicketDetailActivity.this)
+                                    .inflate(R.layout.item_student_attachment_row, llStudentAttachments, false);
+                            ((TextView) row.findViewById(R.id.tvRowFilename)).setText(a.getOriginalFilename());
+                            row.setOnClickListener(v -> {
+                                if (a.getMimeType() != null && a.getMimeType().startsWith("image/")) {
+                                    android.content.Intent intent = new android.content.Intent(
+                                            TicketDetailActivity.this,
+                                            com.example.ucms_android.ui.ImageViewerActivity.class);
+                                    intent.putExtra(
+                                            com.example.ucms_android.ui.ImageViewerActivity.EXTRA_TICKET_ID,
+                                            ticketId);
+                                    startActivity(intent);
+                                }
+                            });
+                            llStudentAttachments.addView(row);
+                        }
+                        llStudentAttachments.setVisibility(View.VISIBLE);
+                        cvAttachment.setVisibility(View.VISIBLE);
+                    } else {
+                        cvAttachment.setVisibility(View.GONE);
+                    }
                 } else {
                     cvAttachment.setVisibility(View.GONE);
                 }

--- a/app/src/main/res/layout/activity_admin_ticket_detail.xml
+++ b/app/src/main/res/layout/activity_admin_ticket_detail.xml
@@ -154,34 +154,15 @@
                                 android:layout_marginTop="20dp"
                                 android:background="@drawable/bg_attachment_box"
                                 android:padding="12dp"
-                                android:clickable="true"
-                                android:focusable="true"
+                                android:orientation="vertical"
                                 android:visibility="gone"
                                 tools:visibility="visible">
 
-                                <ImageView
-                                    android:id="@+id/ivAttachmentImage"
-                                    android:layout_width="20dp"
-                                    android:layout_height="20dp"
-                                    android:src="@drawable/ic_attachment"
-                                    app:tint="?attr/colorTextSecondary" />
-
-                                <TextView
-                                    android:id="@+id/tvAttachmentName"
-                                    android:layout_width="0dp"
+                                <LinearLayout
+                                    android:id="@+id/llStudentAttachments"
+                                    android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
-                                    android:layout_marginStart="12dp"
-                                    android:layout_weight="1"
-                                    android:fontFamily="monospace"
-                                    android:textColor="?attr/colorOnSurface"
-                                    android:textSize="12sp"
-                                    tools:text="image_1000000186.jpg" />
-
-                                <ImageView
-                                    android:layout_width="16dp"
-                                    android:layout_height="16dp"
-                                    android:src="@drawable/ic_chevron_right"
-                                    app:tint="?attr/colorTextSecondary" />
+                                    android:orientation="vertical" />
 
                             </LinearLayout>
 
@@ -368,6 +349,54 @@
                             android:textColor="?attr/colorTextSecondary"
                             android:textSize="10sp"
                             android:textStyle="bold" />
+
+                        <!-- Attachment picker for comment (optional) -->
+                        <FrameLayout
+                            android:id="@+id/cvCommentAttachment"
+                            android:layout_width="match_parent"
+                            android:layout_height="80dp"
+                            android:layout_marginTop="8dp"
+                            android:layout_marginBottom="8dp"
+                            android:background="@drawable/bg_attachment_dashed"
+                            android:clickable="true"
+                            android:focusable="true">
+
+                            <LinearLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="match_parent"
+                                android:gravity="center"
+                                android:orientation="vertical">
+
+                                <ImageView
+                                    android:layout_width="20dp"
+                                    android:layout_height="20dp"
+                                    android:src="@drawable/ic_attachment"
+                                    android:contentDescription="@null"
+                                    app:tint="?attr/colorTextSecondary" />
+
+                                <TextView
+                                    android:id="@+id/tvCommentAttachmentHint"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="6dp"
+                                    android:fontFamily="monospace"
+                                    android:text="TAP TO ATTACH FILE (OPTIONAL)"
+                                    android:textColor="?attr/colorTextSecondary"
+                                    android:textSize="10sp" />
+
+                                <TextView
+                                    android:id="@+id/tvCommentAttachmentName"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="4dp"
+                                    android:fontFamily="monospace"
+                                    android:textColor="?attr/colorHomeSubmitButton"
+                                    android:textStyle="bold"
+                                    android:textSize="10sp"
+                                    android:visibility="gone" />
+
+                            </LinearLayout>
+                        </FrameLayout>
 
                         <!-- Response Input with inline send button -->
                         <FrameLayout

--- a/app/src/main/res/layout/activity_ticket_detail.xml
+++ b/app/src/main/res/layout/activity_ticket_detail.xml
@@ -50,7 +50,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <ScrollView
+        <androidx.core.widget.NestedScrollView
             android:id="@+id/scrollContent"
             android:layout_width="match_parent"
             android:layout_height="0dp"
@@ -219,40 +219,11 @@
                                 </com.facebook.shimmer.ShimmerFrameLayout>
 
                                 <LinearLayout
-                                    android:id="@+id/layoutAttachmentContent"
+                                    android:id="@+id/llStudentAttachments"
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
-                                    android:gravity="center_vertical"
-                                    android:orientation="horizontal"
-                                    android:visibility="gone">
-
-                                    <ImageView
-                                        android:id="@+id/ivAttachmentPreview"
-                                        android:layout_width="20dp"
-                                        android:layout_height="20dp"
-                                        android:contentDescription="@null"
-                                        android:src="@drawable/ic_attachment"
-                                        app:tint="?attr/colorTextSecondary" />
-
-                                    <TextView
-                                        android:id="@+id/tvAttachmentName"
-                                        android:layout_width="0dp"
-                                        android:layout_height="wrap_content"
-                                        android:layout_marginStart="12dp"
-                                        android:layout_weight="1"
-                                        android:fontFamily="monospace"
-                                        android:textColor="?attr/colorOnSurface"
-                                        android:textSize="12sp"
-                                        tools:text="image_1000000186.jpg" />
-
-                                    <ImageView
-                                        android:layout_width="20dp"
-                                        android:layout_height="20dp"
-                                        android:src="@drawable/ic_chevron_right"
-                                        android:contentDescription="@null"
-                                        app:tint="?attr/colorTextSecondary" />
-
-                                </LinearLayout>
+                                    android:orientation="vertical"
+                                    android:visibility="gone" />
 
                             </LinearLayout>
 
@@ -300,7 +271,7 @@
 
             </LinearLayout>
 
-        </ScrollView>
+        </androidx.core.widget.NestedScrollView>
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btnCloseTicketView"

--- a/app/src/main/res/layout/item_admin_response_card.xml
+++ b/app/src/main/res/layout/item_admin_response_card.xml
@@ -59,6 +59,47 @@
             android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
             android:textColor="?attr/colorTextPrimary" />
 
+        <!-- Attachment file row (shown for any attachment type) -->
+        <LinearLayout
+            android:id="@+id/llAttachmentFile"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_attachment_box"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:padding="10dp"
+            android:visibility="gone">
+
+            <ImageView
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_attachment"
+                app:tint="?attr/colorTextSecondary" />
+
+            <TextView
+                android:id="@+id/tvAttachFilename"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:ellipsize="middle"
+                android:fontFamily="monospace"
+                android:singleLine="true"
+                android:textColor="?attr/colorOnSurface"
+                android:textSize="11sp" />
+
+            <ImageView
+                android:layout_width="14dp"
+                android:layout_height="14dp"
+                android:layout_marginStart="8dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_chevron_right"
+                app:tint="?attr/colorTextSecondary" />
+
+        </LinearLayout>
+
     </LinearLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_student_attachment_row.xml
+++ b/app/src/main/res/layout/item_student_attachment_row.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingVertical="8dp">
+
+    <ImageView
+        android:id="@+id/ivRowIcon"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:contentDescription="@null"
+        android:src="@drawable/ic_attachment"
+        app:tint="?attr/colorTextSecondary" />
+
+    <TextView
+        android:id="@+id/tvRowFilename"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_weight="1"
+        android:ellipsize="middle"
+        android:fontFamily="monospace"
+        android:singleLine="true"
+        android:textColor="?attr/colorOnSurface"
+        android:textSize="12sp" />
+
+    <ImageView
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:contentDescription="@null"
+        android:src="@drawable/ic_chevron_right"
+        app:tint="?attr/colorTextSecondary" />
+
+</LinearLayout>


### PR DESCRIPTION
## Type of Change
- [x] feat — new feature

## Labels
<!-- Apply labels from: priority (p0–p3), type (feat/fix/security/chore/docs/test/refactor), scope (backend/android/infra) -->
`p2-medium` `feat` `android`

## What Changed
- Added file picker (image/PDF) to admin comment input in `AdminTicketDetailActivity`
- Added file picker to student `TicketDetailActivity` for sending attachments
- Wired `TimelineAdapter` with ticket ID to support attachment rendering per timeline item
- Added `item_admin_response_card.xml` for admin response card UI
- Added `item_student_attachment_row.xml` for displaying student attachment rows
- Updated `AttachmentResponse` model with additional fields
- Updated `activity_admin_ticket_detail.xml` and `activity_ticket_detail.xml` layouts to include attachment upload UI

## Why
Admins and students previously had no way to attach files (images/PDFs) when responding to or viewing a ticket. This adds that capability to both sides of the ticket detail flow.

## How to Test
1. Log in as an admin and open any ticket detail screen
2. Tap the attachment area in the comment input — a file picker should open (JPEG, PNG, PDF)
3. Select a file and confirm the file name appears in the UI
4. Submit the comment and verify the attachment is sent with the response
5. Log in as a student, open a ticket, and repeat steps 2–4
6. Verify existing comments/timeline render correctly without regression

## Related Issues
<!-- Link related issues: Closes #123 -->

## Screenshots
<!-- For UI changes, add screenshots of before/after -->

## Checklist
- [x] Code follows the Google Java Style Guide
- [x] No logic in Activities or Fragments — use ViewModels
- [x] All API calls go through `ApiClient` — no direct Supabase calls
- [x] JWT attached via `AuthInterceptor` — no manual Authorization headers
- [ ] `403 ACCOUNT_LIMITED` handled with email verification prompt
- [x] No hardcoded dimensions — use `@dimen/` tokens
- [x] No hardcoded colors — use `@color/` tokens
- [x] No hardcoded strings — use `@string/` references
- [x] View IDs follow `camelCase` type prefix convention (`tvTitle`, `btnLogin`, etc.)
- [x] Buttons use `MaterialButton` + `app:cornerRadius="@dimen/corner_radius_button"`
- [x] Cards use `MaterialCardView` + `app:cardCornerRadius="@dimen/corner_radius_card"`
- [x] No secrets or hardcoded URLs committed
- [x] App builds and runs on API 24+
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admins can now attach files when responding to support tickets.
  * Student and admin attachments are displayed separately in ticket details.
  * Image attachments open in a dedicated viewer.
  * Attachments appear inline within the timeline of ticket responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->